### PR TITLE
Netwatcher uses InClusterConfig if --kubeconf argument is not provided.

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -25,7 +25,7 @@ func watchRes(controller cache.Controller) {
 func main() {
   log.SetOutput(os.Stdout)
   log.Println("Starting DANM Watcher...")
-  kubeConfig := flag.String("kubeconf", "admin.conf", "Path to a kube config. Only required if out-of-cluster.")
+  kubeConfig := flag.String("kubeconf", "", "Path to a kube config. Only required if out-of-cluster.")
   flag.Parse()
   config, err := getClientConfig(kubeConfig)
   if err != nil {
@@ -36,7 +36,7 @@ func main() {
   if err != nil {
     log.Println("ERROR: Creation of K8s DanmNet Controller failed with error:" + err.Error() + " , exiting")
     os.Exit(-1)
-  } 
+  }
   dnController := netHandler.CreateController()
   watchRes(dnController)
 


### PR DESCRIPTION
netwatcher wrote the following error log even though --kubeconf argument was not provided and should have used InClusterConfig instead.

/ # /usr/bin/watcher
`2018/10/17 11:33:52 Starting DANM Watcher...
2018/10/17 11:33:52 ERROR: Parsing kubeconfig failed with error:stat admin.conf: no such file or directory , exiting`

Default admin.conf value is now removed from kubeconf flag to allow the usage of InClusterConfig.