### PR TITLE
Minimal travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+pkg/crd/apis/danm/*/zz_generated.deepcopy.go
+pkg/crd/client/
+pkg/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+
+language: ruby
+
+services:
+  - docker
+
+env:
+  - GOPATH=/home/travis/gopath
+
+script:
+  - mkdir -p $GOPATH/{bin,pkg}
+  - mkdir -p $GOPATH/src/github.com/nokia/danm/
+  - mv * $GOPATH/src/github.com/nokia/danm/
+  - cd $GOPATH/src/github.com/nokia/danm/
+  - ./build_danm.sh
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DANM
+[![Build Status](https://travis-ci.org/Nokia/danm.svg?branch=master)](https://travis-ci.org/Nokia/danm)
 <img src="https://github.com/nokia/danm/raw/master/logo.png" width="100">
 
 ## Table of Contents


### PR DESCRIPTION
This is just something very basic.
* there was a nasty dependency on `$GOPATH` environment variable, just plain simple removed it
* creates and maps current dir `bin/` where the executables going to be saved (the mkdir part maybe not ideal)
* added `.gitignore` for the created files
* build status logo for master

Fixes #3