### PR TITLE
Integrate MACVLAN CNI to DANM with dynamic integration level + Extend IP route provisioning support to ALL backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ This way users can dynamically configure various networking solutions via the sa
 A generic framework supporting this method is built into DANM's code, but still this level of integration requires case-by-case implementation.
 As a result, DANM currently supports two integration levels:
 
- - **Dynamic integration level:** CNI-specific network attributes (such as IP ranges, master host devices etc.) can be controlled on a per network level, taken directly from a DanmNet object
- - **Static integration level:** CNI-specific network attributes (such as IP ranges, master host devices etc.) can be only configured on a per node level, via a static CNI configuration files (Note: this is the default CNI configuration method)
+ - **Dynamic integration level:** CNI-specific network attributes (such as IP ranges, parent host devices etc.) can be controlled on a per network level, taken directly from a DanmNet object
+ - **Static integration level:** CNI-specific network attributes (such as IP ranges, parent host devices etc.) can be only configured on a per node level, via a static CNI configuration files (Note: this is the default CNI configuration method)
 
 Our aim is to integrate all the popular CNIs into the DANM eco-system over time, but currently the following CNI's achieved dynamic integration level:
 
@@ -336,8 +336,8 @@ DANM's IPVLAN CNI uses the Linux kernel's IPVLAN module to provision high-speed,
 4.9, 4.11, or 4.14 would be even better (lotta bug fixes)*
 
 The CNI provisions IPVLAN interfaces in L2 mode, and supports the following extra features:
-* attaching IPVLAN slaves to any host interface
-* attaching IPVLAN slaves to dynamically created VLAN or VxLAN host interfaces
+* attaching IPVLAN sub-interfaces to any host interface
+* attaching IPVLAN sub-interfaces to dynamically created VLAN or VxLAN host interfaces
 * renaming the created interfaces according to the "container_prefix" attribute defined in the DanmNet object
 * allocating IP addresses by using DANM's flexible, in-built IPAM module
 * provisioning generic IP routes into a configured routing table inside the Pod's network namespace

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -41,19 +41,18 @@ func readCniConfigFile(netInfo *danmtypes.DanmNet) ([]byte, error) {
 }
 
 //This function creates CNI configuration for the dynamic-level SR-IOV backend
-func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error) {
+func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep *danmtypes.DanmEp) ([]byte, error) {
   vlanid := netInfo.Spec.Options.Vlan
   sriovConfig := sriovNet {
     Name:   netInfo.Spec.NetworkID,
     Type:   "sriov",
     PfName: netInfo.Spec.Options.Device,
-    IfName: netInfo.Spec.Options.Prefix,
+    IfName: ep.Spec.Iface.Name,
     L2Mode: true,
     Vlan:   vlanid,
     Dpdk:   DpdkOption{},
     Ipam:   ipamOptions,
   }
-  sriovConfig.IfName = ep.Spec.Iface.Name
   if ipamOptions.Ip != "" {
     sriovConfig.L2Mode = false
   }
@@ -72,7 +71,7 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamCon
 }
 
 //This function creates CNI configuration for the dynamic-level MACVLAN backend
-func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error) {
+func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep *danmtypes.DanmEp) ([]byte, error) {
   hDev := danmep.DetermineHostDeviceName(netInfo)
   macvlanConfig := macvlanNet {
     Master: hDev,

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -1,0 +1,89 @@
+package cnidel
+
+import (  
+  "errors"
+  "io/ioutil"
+  "encoding/json"
+  "github.com/nokia/danm/pkg/danmep"
+  danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
+)
+
+var (
+  supportedNativeCnis = []*cniBackendConfig {
+    &cniBackendConfig {
+      danmtypes.CniBackend {
+        BackendName: "sriov",
+        CniVersion: "0.3.1",
+      },
+      cniConfigReader(getSriovCniConfig),
+      true,
+    },
+    &cniBackendConfig {
+      danmtypes.CniBackend {
+        BackendName: "macvlan",
+        CniVersion: "0.3.1",
+      },
+      cniConfigReader(getMacvlanCniConfig),
+      true,
+    },
+  }
+)
+
+//This function creates CNI configuration for all static-level backends
+func readCniConfigFile(netInfo *danmtypes.DanmNet) ([]byte, error) {
+  cniType := netInfo.Spec.NetworkType
+  //TODO: the path from where the config is read should not be hard-coded
+  rawConfig, err := ioutil.ReadFile("/etc/cni/net.d/" + cniType + ".conf")
+  if err != nil {
+    return nil, errors.New("Could not load CNI config file for plugin:" + cniType)
+  }
+  return rawConfig, nil
+}
+
+//This function creates CNI configuration for the dynamic-level SR-IOV backend
+func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error) {
+  vlanid := netInfo.Spec.Options.Vlan
+  sriovConfig := sriovNet {
+    Name:   netInfo.Spec.NetworkID,
+    Type:   "sriov",
+    PfName: netInfo.Spec.Options.Device,
+    IfName: netInfo.Spec.Options.Prefix,
+    L2Mode: true,
+    Vlan:   vlanid,
+    Dpdk:   DpdkOption{},
+    Ipam:   ipamOptions,
+  }
+  sriovConfig.IfName = CalculateIfaceName(netInfo.Spec.Options.Prefix, nicParams.DefaultIfaceName)
+  if ipamOptions.Ip != "" {
+    sriovConfig.L2Mode = false
+  }
+  if netInfo.Spec.Options.Dpdk {
+    sriovConfig.Dpdk = DpdkOption {
+      NicDriver: dpdkNicDriver,
+      DpdkDriver: dpdkDriver,
+      DpdkTool: dpdkTool,
+    }
+  }
+  rawConfig, err := json.Marshal(sriovConfig)
+  if err != nil {
+    return nil, errors.New("Error putting together CNI config for SR-IOV plugin: " + err.Error())
+  }
+  return rawConfig, nil
+}
+
+//This function creates CNI configuration for the dynamic-level MACVLAN backend
+func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error) {
+  hDev := danmep.DetermineHostDeviceName(netInfo)
+  macvlanConfig := macvlanNet {
+    Master: hDev,
+   //TODO: make these params configurable if required
+    Mode:   "bridge",
+    MTU:    1500,
+    Ipam:   ipamOptions,
+  }
+  rawConfig, err := json.Marshal(macvlanConfig)
+  if err != nil {
+    return nil, errors.New("Error putting together CNI config for MACVLAN plugin: " + err.Error())
+  }
+  return rawConfig, nil
+}

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -2,6 +2,7 @@ package cnidel
 
 import (  
   "errors"
+  "log"
   "io/ioutil"
   "encoding/json"
   "github.com/nokia/danm/pkg/danmep"
@@ -80,6 +81,7 @@ func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamC
     MTU:    1500,
     Ipam:   ipamOptions,
   }
+  log.Printf("LOFASZ MACVLAN CONFIG %v/n",macvlanConfig)
   rawConfig, err := json.Marshal(macvlanConfig)
   if err != nil {
     return nil, errors.New("Error putting together CNI config for MACVLAN plugin: " + err.Error())

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -41,7 +41,7 @@ func readCniConfigFile(netInfo *danmtypes.DanmNet) ([]byte, error) {
 }
 
 //This function creates CNI configuration for the dynamic-level SR-IOV backend
-func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error) {
+func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error) {
   vlanid := netInfo.Spec.Options.Vlan
   sriovConfig := sriovNet {
     Name:   netInfo.Spec.NetworkID,
@@ -53,7 +53,7 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamCon
     Dpdk:   DpdkOption{},
     Ipam:   ipamOptions,
   }
-  sriovConfig.IfName = CalculateIfaceName(netInfo.Spec.Options.Prefix, nicParams.DefaultIfaceName)
+  sriovConfig.IfName = ep.Spec.Iface.Name
   if ipamOptions.Ip != "" {
     sriovConfig.L2Mode = false
   }
@@ -72,7 +72,7 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamCon
 }
 
 //This function creates CNI configuration for the dynamic-level MACVLAN backend
-func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error) {
+func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error) {
   hDev := danmep.DetermineHostDeviceName(netInfo)
   macvlanConfig := macvlanNet {
     Master: hDev,

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -43,7 +43,7 @@ func IsDelegationRequired(danmClient danmclientset.Interface, nid, namespace str
 
 // DelegateInterfaceSetup delegates K8s Pod network interface setup task to the input 3rd party CNI plugin
 // Returns the CNI compatible result object, or an error if interface creation was unsuccessful, or if the 3rd party CNI config could not be loaded
-func DelegateInterfaceSetup(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, iface danmtypes.Interface, ep danmtypes.DanmEp) (types.Result,error) {
+func DelegateInterfaceSetup(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ep danmtypes.DanmEp) (types.Result,error) {
   var (
     ip4 string
     ip6 string
@@ -51,19 +51,19 @@ func DelegateInterfaceSetup(danmClient danmclientset.Interface, netInfo *danmtyp
     ipamOptions danmtypes.IpamConfig
   )
   if isIpamNeeded(netInfo.Spec.NetworkType) {
-    ip4, ip6, _, err = ipam.Reserve(danmClient, *netInfo, iface.Ip, iface.Ip6)
+    ip4, ip6, _, err = ipam.Reserve(danmClient, *netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     if err != nil {
       return nil, errors.New("IP address reservation failed for network:" + netInfo.Spec.NetworkID + " with error:" + err.Error())
     }
     ipamOptions = getCniIpamConfig(netInfo.Spec.Options, ip4, ip6)
   }
-  rawConfig, err := getCniPluginConfig(netInfo, ipamOptions, iface)
+  rawConfig, err := getCniPluginConfig(netInfo, ipamOptions, ep)
   if err != nil {
     freeDelegatedIps(danmClient, netInfo, ip4, ip6)
     return nil, err
   }
   cniType := netInfo.Spec.NetworkType
-  cniResult,err := execCniPlugin(cniType, netInfo, iface, rawConfig)
+  cniResult,err := execCniPlugin(cniType, netInfo, rawConfig, ep)
   if err != nil {
     freeDelegatedIps(danmClient, netInfo, ip4, ip6)
     return nil, errors.New("Error delegating ADD to CNI plugin:" + cniType + " because:" + err.Error())
@@ -110,11 +110,11 @@ func getCniIpamConfig(options danmtypes.DanmNetOption, ip4 string, ip6 string) d
   }
 }
 
-func getCniPluginConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error) {
+func getCniPluginConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error) {
   cniType := netInfo.Spec.NetworkType
   for _, cni := range supportedNativeCnis {
     if cni.BackendName == cniType {
-      return cni.readConfig(netInfo, ipamOptions, nicParams)
+      return cni.readConfig(netInfo, ipamOptions, ep)
     }
   }
   return readCniConfigFile(netInfo)
@@ -135,8 +135,8 @@ func parseRoutes(rawRoutes map[string]string, netCidr string) ([]danmtypes.IpamR
   return routes, defaultGw
 }
 
-func execCniPlugin(cniType string, netInfo *danmtypes.DanmNet, nicParams danmtypes.Interface, rawConfig []byte) (types.Result,error) {
-  cniPath, cniArgs, err := getExecCniParams(cniType, netInfo, nicParams)
+func execCniPlugin(cniType string, netInfo *danmtypes.DanmNet, rawConfig []byte, ep danmtypes.DanmEp) (types.Result,error) {
+  cniPath, cniArgs, err := getExecCniParams(cniType, netInfo, ep)
   if err != nil {
     return nil, err
   }
@@ -153,7 +153,7 @@ func execCniPlugin(cniType string, netInfo *danmtypes.DanmNet, nicParams danmtyp
   return version.NewResult(confVersion, rawResult)
 }
 
-func getExecCniParams(cniType string, netInfo *danmtypes.DanmNet, nicParams danmtypes.Interface) (string,[]string,error) {
+func getExecCniParams(cniType string, netInfo *danmtypes.DanmNet, ep danmtypes.DanmEp) (string,[]string,error) {
   cniPaths := filepath.SplitList(os.Getenv("CNI_PATH"))
   cniPath, err := invoke.FindInPath(cniType, cniPaths)
   if err != nil {
@@ -163,7 +163,7 @@ func getExecCniParams(cniType string, netInfo *danmtypes.DanmNet, nicParams danm
     "CNI_COMMAND="     + os.Getenv("CNI_COMMAND"),
     "CNI_CONTAINERID=" + os.Getenv("CNI_CONTAINERID"),
     "CNI_NETNS="       + os.Getenv("CNI_NETNS"),
-    "CNI_IFNAME="      + CalculateIfaceName(netInfo.Spec.Options.Prefix, nicParams.DefaultIfaceName),
+    "CNI_IFNAME="      + ep.Spec.Iface.Name,
     "CNI_ARGS="        + os.Getenv("CNI_ARGS"),
     "CNI_PATH="        + os.Getenv("CNI_PATH"),
   }
@@ -172,8 +172,8 @@ func getExecCniParams(cniType string, netInfo *danmtypes.DanmNet, nicParams danm
 
 // DelegateInterfaceDelete delegates Ks8 Pod network interface delete task to the input 3rd party CNI plugin
 // Returns an error if interface creation was unsuccessful, or if the 3rd party CNI config could not be loaded
-func DelegateInterfaceDelete(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ip string) error {
-  rawConfig, err := getCniPluginConfig(netInfo, danmtypes.IpamConfig{}, danmtypes.Interface{})
+func DelegateInterfaceDelete(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ep danmtypes.DanmEp) error {
+  rawConfig, err := getCniPluginConfig(netInfo, danmtypes.IpamConfig{}, ep)
   if err != nil {
     return err
   }
@@ -181,10 +181,10 @@ func DelegateInterfaceDelete(danmClient danmclientset.Interface, netInfo *danmty
   err = invoke.DelegateDel(cniType, rawConfig)
   if err != nil {
     //Best-effort clean-up because we know how to handle exceptions
-    freeDelegatedIp(danmClient, netInfo, ip)
+    freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     return errors.New("Error delegating DEL to CNI plugin:" + cniType + " because:" + err.Error())
   }
-  return freeDelegatedIp(danmClient, netInfo, ip)
+  return freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
 }
 
 func freeDelegatedIps(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ip4, ip6 string) error {

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -14,6 +14,7 @@ import (
   "github.com/containernetworking/cni/pkg/types/current"
   "github.com/containernetworking/cni/pkg/version"
   "github.com/nokia/danm/pkg/ipam"
+  "github.com/nokia/danm/pkg/danmep"
   danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
   danmclientset "github.com/nokia/danm/pkg/crd/client/clientset/versioned"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,53 +24,9 @@ var (
   ipamType = "fakeipam"
   defaultDataDir = "/var/lib/cni/networks"
   flannelBridge = getEnv("FLANNEL_BRIDGE", "cbr0")
-)
-
-type cniBackendConfig struct {
-  danmtypes.CniBackend
-  readConfig cniConfigReader
-  ipamNeeded bool
-}
-
-type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error)
-
-// sriovNet represent the configuration of sriov plugin
-type sriovNet struct {
-  // the name of the network
-  Name   string     `json:"name"`
-  // currently constant "sriov"
-  Type   string     `json:"type"`
-  // name of the PF
-  PfName string     `json:"if0"`
-  // interface name in the Container
-  IfName string     `json:"if0name,omitEmpty"`
-  // if true then add VF as L2 mode only, IPAM will not be executed
-  L2Mode bool       `json:"l2enable,omitEmpty"`
-  // VLAN ID to assign for the VF
-  Vlan   int        `json:"vlan,omitEmpty"`
-  // IPAM configuration to be used for this network.
-  Ipam   danmtypes.IpamConfig `json:"ipam,omitEmpty"`
-  // DPDK configuration
-  Dpdk   DpdkOption `json:"dpdk,omitEmpty"`
-}
-
-// DpdkOption represents the DPDK options for the sriov plugin
-type DpdkOption struct {
-  // The name of kernel NIC driver
-  NicDriver  string `json:"kernel_driver"`
-  // The name of DPDK capable driver
-  DpdkDriver string `json:"dpdk_driver"`
-  // Path to the dpdk-devbind.py script
-  DpdkTool   string `json:"dpdk_tool"`
-}
-
-var (
   dpdkNicDriver = os.Getenv("DPDK_NIC_DRIVER")
   dpdkDriver = os.Getenv("DPDK_DRIVER")
   dpdkTool = os.Getenv("DPDK_TOOL")
-)
-
-var (
   supportedNativeCnis = []*cniBackendConfig {
     &cniBackendConfig {
       danmtypes.CniBackend {
@@ -77,6 +34,14 @@ var (
         CniVersion: "0.3.1",
       },
       cniConfigReader(getSriovCniConfig),
+      true,
+    },
+    &cniBackendConfig {
+      danmtypes.CniBackend {
+        BackendName: "macvlan",
+        CniVersion: "0.3.1",
+      },
+      cniConfigReader(getMacvlanCniConfig),
       true,
     },
   }
@@ -96,7 +61,7 @@ func IsDelegationRequired(danmClient danmclientset.Interface, nid, namespace str
   return true, netInfo, nil
 }
 
-// DelegateInterfaceSetup delegates Ks8 Pod network interface setup task to the input 3rd party CNI plugin
+// DelegateInterfaceSetup delegates K8s Pod network interface setup task to the input 3rd party CNI plugin
 // Returns the CNI compatible result object, or an error if interface creation was unsuccessful, or if the 3rd party CNI config could not be loaded
 func DelegateInterfaceSetup(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, iface danmtypes.Interface) (types.Result,error) {
   var (
@@ -170,6 +135,21 @@ func getCniPluginConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamCo
   return readCniConfigFile(netInfo)
 }
 
+func parseRoutes(rawRoutes map[string]string, netCidr string) ([]danmtypes.IpamRoute, string) {
+  defaultGw := ""
+  routes := []danmtypes.IpamRoute{}
+  for dst, gw := range rawRoutes {
+    routes = append(routes, danmtypes.IpamRoute{
+      Dst: dst,
+      Gw: gw,
+    })
+    if _, sn, _ := net.ParseCIDR(dst); sn.String() == netCidr {
+      defaultGw = gw
+    }
+  }
+  return routes, defaultGw
+}
+
 func execCniPlugin(cniType string, netInfo *danmtypes.DanmNet, nicParams danmtypes.Interface, rawConfig []byte) (types.Result,error) {
   cniPath, cniArgs, err := getExecCniParams(cniType, netInfo, nicParams)
   if err != nil {
@@ -230,7 +210,23 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamCon
   }
   rawConfig, err := json.Marshal(sriovConfig)
   if err != nil {
-    return nil, errors.New("Error getting sriov plugin config: " + err.Error())
+    return nil, errors.New("Error putting together CNI config for SR-IOV plugin: " + err.Error())
+  }
+  return rawConfig, nil
+}
+
+func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig) ([]byte, error) {
+  hDev := danmep.DetermineHostDeviceName(netInfo)
+  macvlanConfig := macvlanNet {
+    Master: hDev,
+   //TODO: make these params configurable if required
+    Mode:   "bridge",
+    MTU:    1500,
+    Ipam:   ipamOptions,
+  }
+  rawConfig, err := json.Marshal(macvlanConfig)
+  if err != nil {
+    return nil, errors.New("Error putting together CNI config for MACVLAN plugin: " + err.Error())
   }
   return rawConfig, nil
 }
@@ -243,21 +239,6 @@ func readCniConfigFile(netInfo *danmtypes.DanmNet) ([]byte, error) {
     return nil, errors.New("Could not load CNI config file for plugin:" + cniType)
   }
   return rawConfig, nil
-}
-
-func parseRoutes(rawRoutes map[string]string, netCidr string) ([]danmtypes.IpamRoute, string) {
-  defaultGw := ""
-  routes := []danmtypes.IpamRoute{}
-  for dst, gw := range rawRoutes {
-    routes = append(routes, danmtypes.IpamRoute{
-      Dst: dst,
-      Gw: gw,
-    })
-    if _, sn, _ := net.ParseCIDR(dst); sn.String() == netCidr {
-      defaultGw = gw
-    }
-  }
-  return routes, defaultGw
 }
 
 // DelegateInterfaceDelete delegates Ks8 Pod network interface delete task to the input 3rd party CNI plugin

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -4,7 +4,7 @@ import (
   danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
 )
 
-type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error)
+type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, ep *danmtypes.DanmEp) ([]byte, error)
 
 type cniBackendConfig struct {
   danmtypes.CniBackend

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -4,7 +4,7 @@ import (
   danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
 )
 
-type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig) ([]byte, error)
+type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error)
 
 type cniBackendConfig struct {
   danmtypes.CniBackend

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -4,7 +4,7 @@ import (
   danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
 )
 
-type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, nicParams danmtypes.Interface) ([]byte, error)
+type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, ep danmtypes.DanmEp) ([]byte, error)
 
 type cniBackendConfig struct {
   danmtypes.CniBackend

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -1,0 +1,54 @@
+package cnidel
+
+import (
+  danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
+)
+
+type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig) ([]byte, error)
+
+type cniBackendConfig struct {
+  danmtypes.CniBackend
+  readConfig cniConfigReader
+  ipamNeeded bool
+}
+
+// sriovNet represent the configuration of sriov plugin
+type sriovNet struct {
+  // the name of the network
+  Name   string     `json:"name"`
+  // currently constant "sriov"
+  Type   string     `json:"type"`
+  // name of the PF
+  PfName string     `json:"if0"`
+  // interface name in the Container
+  IfName string     `json:"if0name,omitEmpty"`
+  // if true then add VF as L2 mode only, IPAM will not be executed
+  L2Mode bool       `json:"l2enable,omitEmpty"`
+  // VLAN ID to assign for the VF
+  Vlan   int        `json:"vlan,omitEmpty"`
+  // IPAM configuration to be used for this network
+  Ipam   danmtypes.IpamConfig `json:"ipam,omitEmpty"`
+  // DPDK configuration
+  Dpdk   DpdkOption `json:"dpdk,omitEmpty"`
+}
+
+// DpdkOption represents the DPDK options for the sriov plugin
+type DpdkOption struct {
+  // The name of kernel NIC driver
+  NicDriver  string `json:"kernel_driver"`
+  // The name of DPDK capable driver
+  DpdkDriver string `json:"dpdk_driver"`
+  // Path to the dpdk-devbind.py script
+  DpdkTool   string `json:"dpdk_tool"`
+}
+
+type macvlanNet struct {
+  //Name of the master NIC the MACVLAN slave needs to be connected to
+  Master string `json:"master"`
+  //The mode in which the MACVLAN slave is configured (default bridge)
+  Mode   string `json:"mode"`
+  //MTU to be set to the MACVLAN slave interface (default 1500)
+  MTU    int    `json:"mtu"`
+  //IPAM configuration to be used for this network
+  Ipam   danmtypes.IpamConfig `json:"ipam,omitEmpty"`
+}

--- a/pkg/danm/danm.go
+++ b/pkg/danm/danm.go
@@ -233,30 +233,15 @@ func createDelegatedInterface(danmClient danmclientset.Interface, iface danmtype
   if err != nil {
     return nil, errors.New("DanmEp object could not be created due to error:" + err.Error())
   }
-  delegateResult,err := cnidel.DelegateInterfaceSetup(danmClient, netInfo, &ep)
+  delegatedResult,err := cnidel.DelegateInterfaceSetup(danmClient, netInfo, &ep)
   if err != nil {
     return nil, err
-  }
-  delegatedResult := cnidel.ConvertCniResult(delegateResult)
-  if delegatedResult != nil {
-    setEpIfaceAddress(delegatedResult, &ep.Spec.Iface)
   }
   err = putDanmEp(args, ep)
   if err != nil {
     return nil, errors.New("DanmEp object could not be PUT to K8s due to error:" + err.Error())
   }
   return delegatedResult, nil
-}
-
-func setEpIfaceAddress(cniResult *current.Result, epIface *danmtypes.DanmEpIface) error {
-  for _, ip := range cniResult.IPs {
-    if ip.Version == "4" {
-      epIface.Address = ip.Address.String()
-    } else {
-      epIface.AddressIPv6 = ip.Address.String()
-    }
-  }
-  return nil
 }
 
 func createDanmInterface(danmClient danmclientset.Interface, iface danmtypes.Interface, netInfo *danmtypes.DanmNet, args *cniArgs) (*current.Result,error) {

--- a/pkg/danmep/danmep.go
+++ b/pkg/danmep/danmep.go
@@ -93,7 +93,7 @@ func CreateRoutesInNetNs(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, ) error {
     hns.Close()
     err = origNs.Set()
     if err != nil {
-      log.Println("Could not switch back to default ns during IPVLAN interface creation:" + err.Error())
+      log.Println("Could not switch back to default ns during IP route provisioning operation:" + err.Error())
     }
   }()
   err = hns.Set()

--- a/pkg/danmep/danmep.go
+++ b/pkg/danmep/danmep.go
@@ -2,6 +2,7 @@ package danmep
 
 import (
   "log"
+  "strconv"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
   danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"
   danmclientset "github.com/nokia/danm/pkg/crd/client/clientset/versioned"
@@ -57,4 +58,19 @@ func AddIpvlanInterface(dnet *danmtypes.DanmNet, ep danmtypes.DanmEp) error {
     return nil
   }
   return createIpvlanInterface(dnet, ep)
+}
+
+func DetermineHostDeviceName(dnet *danmtypes.DanmNet) string {
+  var device string
+  isVlanDefined := (dnet.Spec.Options.Vlan!=0)
+  isVxlanDefined := (dnet.Spec.Options.Vxlan!=0)
+  if isVxlanDefined {
+    device = "vx_" + dnet.Spec.NetworkID
+  } else if isVlanDefined {
+    vlanId := strconv.Itoa(dnet.Spec.Options.Vlan)
+    device = dnet.Spec.NetworkID + "." + vlanId
+  } else {
+    device = dnet.Spec.Options.Device
+  }
+  return device
 }

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -97,7 +97,7 @@ func createContainerIface(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, device s
     }
   }
   ip6 := ep.Spec.Iface.AddressIPv6
-  // TODO: Refactor, duplicate of 97-108
+  // TODO: Refactor, duplicate of 87-98
   if ip6 != "" {
     addr6, pref,  err := net.ParseCIDR(ip6)
     if err != nil {
@@ -119,7 +119,10 @@ func createContainerIface(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, device s
     return errors.New("cannot set renamed IPVLAN interface to up because:" + err.Error())
   }
   sendGratArps(ip, ip6, dstPrefix)
-  addIpRoutes(ep, dnet)
+  err = addIpRoutes(ep, dnet)
+  if err != nil {
+    return errors.New("IP routes could not be provisioned, because:" + err.Error())
+  }
   return nil
 }
 

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -26,7 +26,7 @@ func createIpvlanInterface(dnet *danmtypes.DanmNet, ep danmtypes.DanmEp) error {
   if ns.IsNSorErr(ep.Spec.Netns) != nil {
     return errors.New("Cannot get container pid!")
   }
-  device := determineIfName(dnet)
+  device := DetermineHostDeviceName(dnet)
   return createContainerIface(ep, dnet, device)
 }
 

--- a/pkg/danmnet/danmnet.go
+++ b/pkg/danmnet/danmnet.go
@@ -2,9 +2,9 @@ package danmnet
 
 import (
   "log"
+  "reflect"
   "strings"
   "time"
-  "reflect"
   "k8s.io/client-go/rest"
   "k8s.io/client-go/tools/cache"
   danmtypes "github.com/nokia/danm/pkg/crd/apis/danm/v1"

--- a/pkg/danmnet/net.go
+++ b/pkg/danmnet/net.go
@@ -6,7 +6,6 @@ import (
   "math"
   "math/big"
   "net"
-  "strings"
   "strconv"
   "syscall"
   "github.com/apparentlymart/go-cidr/cidr"
@@ -65,15 +64,9 @@ func Int2ip6(nn *big.Int) net.IP {
 }
 
 func validateNetwork(dnet *danmtypes.DanmNet) error {
-  cniType := dnet.Spec.NetworkType
-  if cniType == "" {
-    cniType = "ipvlan"
-  }
-  dnet.Spec.NetworkType = strings.ToLower(cniType)
-  for _,supportedCni := range nativelySupportedCnis {
-    if supportedCni == dnet.Spec.NetworkType {
-      return validateDanmNet(dnet)
-    }
+  err := validateDanmNet(dnet)
+  if err != nil {
+    return err
   }
   validate(dnet)
   return nil

--- a/pkg/danmnet/net.go
+++ b/pkg/danmnet/net.go
@@ -22,10 +22,6 @@ const (
   maxVxlanId = 16777214
 )
 
-var (
-  nativelySupportedCnis = []string{"ipvlan","sriov"}
-)
-
 // LinkInfo is an absract struct to represent a host NIC of a special type: either VLAN, or VxLAN
 // The ID of the link is stored together with its Golang representation
 type LinkInfo struct {
@@ -85,7 +81,6 @@ func validateDanmNet(dnet *danmtypes.DanmNet) error {
   if err != nil {
     return err
   }
-  validate(dnet)
   return nil
 }
 
@@ -231,9 +226,6 @@ func validate(dnet *danmtypes.DanmNet) {
 func setupHost(dnet *danmtypes.DanmNet) error {
   netId := dnet.Spec.NetworkID
   hdev := dnet.Spec.Options.Device
-  if dnet.Spec.NetworkType != "ipvlan" {
-    return nil
-  }
   vxlanId := dnet.Spec.Options.Vxlan
   vlanId := dnet.Spec.Options.Vlan
   // Nothing to do here

--- a/pkg/glide.lock
+++ b/pkg/glide.lock
@@ -1,5 +1,5 @@
 hash: c733add746209fb2636606d30af3b2279aa2e51c786422ad39052596bdfc25a1
-updated: 2018-12-04T18:31:09.317027749+01:00
+updated: 2019-01-25T15:34:49.348804593+01:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
@@ -15,7 +15,7 @@ imports:
   - pkg/types/current
   - pkg/version
 - name: github.com/containernetworking/plugins
-  version: 3fb464786f10fc38da40a65575dbb8ea4b3a43c3
+  version: a686cc4bd84f77d93115f6f3e0ec894d55be178e
   subpackages:
   - pkg/ns
 - name: github.com/davecgh/go-spew

--- a/schema/DanmNet.yaml
+++ b/schema/DanmNet.yaml
@@ -18,9 +18,9 @@ spec:
   NetworkID: ## NETWORK_NAME  ##
   # This parameter, if present, denotes which backend willl be used to provision the container interfaces connected to this network.
   # Currently supported values with dynamic integration level are IPVLAN (default), SRIOV, or MACVLAN.
-  # - IPVLAN option results in an IPVLAN slave interface provisioned in L2 mode, and connected to the designated host device
+  # - IPVLAN option results in an IPVLAN sub-interface provisioned in L2 mode, and connected to the designated host device
   # - SRIOV option pushes an already existing Virtual Function of the configured host device to the container's netns
-  # - MACVLAN option results in a MACVLAN slave interface provisioned in bridge mode, and connected to the designated host device
+  # - MACVLAN option results in a MACVLAN sub-interface provisioned in bridge mode, and connected to the designated host device
   # For any other CNI backend DANM will read their configuration from the configured CNI config directory.
   # E.g. when a Pod is connected to a DanmNet with "NetworkType" set to "flannel", DANM will pass the content of /etc/cni/net.d/flannel.conf file to the /opt/cni/bin/flannel binary by invoking a standard CNI operation.
   # The default IPVLAN backend will be used if this parameter is not specified.
@@ -31,11 +31,11 @@ spec:
   # Dynamic configuration is supported only for IPVLAN, and SRIOV backends.
   # Other networks are always provisioned from static configuration. Options are silently ignored if NetworkType is set to a non-dynamically integrated backend.
   Options:
-    # Name of the master host device (i.e. physical host NIC).
-    # Slave interfaces are connected to this NIC in case NetworkType is set to IPVLAN, or MACVLAN.
+    # Name of the parent host device (i.e. physical host NIC).
+    # Sub-interfaces are connected to this NIC in case NetworkType is set to IPVLAN, or MACVLAN.
     # A Virtual Function belonging to this Physical Function is taken-up in case NetworkType is set to SRIOV.
     # OPTIONAL - STRING
-    host_device: ## MASTER_DEVICE_NAME ##
+    host_device: ## PARENT_DEVICE_NAME ##
     # The IPv4 CIDR notation of the subnet associated with the network.
     # Pods connecting to this network will get their IPs from this subnet, if defined.
     # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.

--- a/schema/DanmNet.yaml
+++ b/schema/DanmNet.yaml
@@ -1,6 +1,6 @@
 ### K8s DanmNet template ###
 apiVersion: danm.k8s.io/v1
-# This is a 3rd party addition to a K8s cluster. 
+# This is a 3rd party addition to a K8s cluster.
 # A DamnNet object represents a physical network together with its resources and configuration applications can use.
 # The DANM will always connect K8s pods to K8s DanmNets.
 kind: DanmNet
@@ -17,9 +17,10 @@ spec:
   # MANDATORY - STRING
   NetworkID: ## NETWORK_NAME  ##
   # This parameter, if present, denotes which backend willl be used to provision the container interfaces connected to this network.
-  # Currently supported values with dynamic integration level are IPVLAN (default), or SRIOV.
+  # Currently supported values with dynamic integration level are IPVLAN (default), SRIOV, or MACVLAN.
   # - IPVLAN option results in an IPVLAN slave interface provisioned in L2 mode, and connected to the designated host device
   # - SRIOV option pushes an already existing Virtual Function of the configured host device to the container's netns
+  # - MACVLAN option results in a MACVLAN slave interface provisioned in bridge mode, and connected to the designated host device
   # For any other CNI backend DANM will read their configuration from the configured CNI config directory.
   # E.g. when a Pod is connected to a DanmNet with "NetworkType" set to "flannel", DANM will pass the content of /etc/cni/net.d/flannel.conf file to the /opt/cni/bin/flannel binary by invoking a standard CNI operation.
   # The default IPVLAN backend will be used if this parameter is not specified.
@@ -31,42 +32,47 @@ spec:
   # Other networks are always provisioned from static configuration. Options are silently ignored if NetworkType is set to a non-dynamically integrated backend.
   Options:
     # Name of the master host device (i.e. physical host NIC).
-    # Slave interfaces are connected to this NIC in case NetworkType is set to IPVLAN.
+    # Slave interfaces are connected to this NIC in case NetworkType is set to IPVLAN, or MACVLAN.
     # A Virtual Function belonging to this Physical Function is taken-up in case NetworkType is set to SRIOV.
     # OPTIONAL - STRING
     host_device: ## MASTER_DEVICE_NAME ##
-    # The IPv4 CIDR notation of the subnet associated with the network. 
+    # The IPv4 CIDR notation of the subnet associated with the network.
     # Pods connecting to this network will get their IPs from this subnet, if defined.
+    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
     # OPTIONAL - CIDR FORMAT (e.g. "10.0.0.0/24")
     cidr: ## SUBNET_CIDR ##
     # IP allocation will be done according to the narrowed down allocation pool parameter, if defined.
     # Allocation pool must be provided together with CIDR, and shall be aligned with the CIDR subnet range.
+    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
     # OPTIONAL - IPV4 FORMAT (e.g. "10.0.0.10")
     allocation_pool:
       start: ## FIRST_ASSIGNABLE_IP ##
       end: ## LAST_ASSIGNABLE_IP ##
     # Interfaces connected to this network will be renamed to "container_prefix" inside the container.
     # If not provided, DANM will dynamically allocate a name for each container interface belonging to this network in Pod instantiation time.
+    # Generally supported parameter, works with all NetworkTypes.
     # OPTIONAL - STRING
     container_prefix: ## INTERNAL_IF_NAME ##
-    # IP routes belonging to this network will be installed in this routing table
+    # Policy-based IP routes belonging to this network will be installed in this routing table, if a Pod asks for them.
+    # Generally supported parameter, works with all NetworkTypes.
     # OPTIONAL - INTEGER (e.g. 201)
     rt_tables: ## HOST_UNIQUE_ROUTING_TABLE_NUMBER ##
     # IPv4 routes to be installed by default for all containers connected to this network
-    # Provisioning L3 IP routes is not supported for SRIOV networks.
+    # Generally supported parameter, works with all NetworkTypes.
     # OPTIONAL - LIST OF DESTINATION_IPV4_CIDR:IPV4_GW ENTRIES (e.g. "10.20.0.0/24: 10.0.0.1")
-    routes: 
+    routes:
       ## IP_ROUTE_1 ##
       ## IP_ROUTE_2 ##
     # If this parameter is present then traffic going through this network will be VxLAN tagged with the provided identifier
     # The VxLAN tag shall be unique on the level of the underlying host.
-    # Management of the VxLAN interface is handled automatically by DANM.
-    # Dynamic VxLAN tagging is not supported for SRIOV networks.
+    # Management of the VxLAN interface is handled automatically by DANM. Provisioning is generally supported for all NetworkTypes.
+    # Only IPVLAN, and MACVLAN interfaces will be automatically connected to the provisioned VxLAN.
     # OPTIONAL - INTEGER (e.g. 50)
     vxlan: ## VXLAN_TAG ##
     # If this parameter is present then traffic going through this network will be VLAN tagged with the provided identifier
     # The VLAN ID shall be unique on the level of the underlying host.
-    # Management of the VLAN interface is handled automatically by DANM.
+    # Management of the VLAN interface is handled automatically by DANM. Provisioning is generally supported for all NetworkTypes.
+    # Only dynamically supported NetworkType interfaces will be automatically connected to the provisioned VLAN.
     # VLAN and VxLAN paramaters are mutually exclusive! Defining both in the same DanmNet will result in a validation error!
     # OPTIONAL - INTEGER (e.g. 4000)
     vlan: ## VLAN_TAG ##

--- a/schema/network_attach.yaml
+++ b/schema/network_attach.yaml
@@ -8,18 +8,18 @@ metadata:
   # Name of the K8s object this file represents
   # MANDATORY - STRING
   name: ## OBJECT_NAME  ##
-  
+
   # The K8 namespace the object belongs to.
   # DanmNets are namespaces resources, so a Pod can only connect to a DanmNet if it resides in the same namespace.
   # MANDATORY - STRING
   namespace: ## NS_NAME  ##
-  
+
 spec:
   # The specification body of the K8s object according to its default K8s API schema
   # MANDATORY
   template:
     metadata:
-      annotations: 
+      annotations:
       # DANM shall be driven with networking related requirements stated in this JSON formatted field.
       # Each entry listed in danm.k8s.io/interfaces annotation results in a network interface provisioned into the Pod's network namespace created by this K8s object.
       # The interface is provisioned via the backend specified in the referenced DanmNet (or with DANM's in-built IPVLAN CNI by default).
@@ -28,23 +28,27 @@ spec:
       # MANDATORY - LIST OF REQUIRED NETWORK INTERFACES
       #   One network connection can have the following attributes:
       #   "network": NetworkID of the DanmNet to which the interface should be connected to. MANDATORY PARAMETER
-      #   "ip": desired IPv4 address assigment scheme. 
+      #   "ip": desired IPv4 address assigment scheme.
+      #     Ignored for non-dynamic NetworkTypes.
       #     OPTIONAL PARAMETER - but either "ip" or "ip6" needs to be present. Presence of either "ip" or "ip6" is MANDATORY
       #     Possible values:
       #     - "dynamic": the first free IPv4 address is dynamically allocated from the DanmNet's allocation pool
       #     - "## DESIRED_STATIC_IPV4_ADDR_FROM_ALLOCATION_POOL (e.g. "10.10.0.101/24") ##"
       #     - "none": no IPv4 is allocated to the interface
       #   "ip6": desired IPv6 address assigment scheme.
+      #     Ignored for non-dynamic NetworkTypes.
       #     OPTIONAL PARAMETER - but either "ip" or "ip6" needs to be present. Presence of either "ip" or "ip6" is MANDATORY
       #     Possible values:
       #     - "dynamic": the first free IPv6 address is dynamically allocated from the DanmNet's allocation pool
       #     - "## DESIRED_STATIC_IPV6_ADDR_FROM_ALLOCATION_POOL ##"
       #     - "none": no IPv6 address is allocated to the interface
-      #   "proutes": list of policy-based IPv4 routes to be added to the routing table of this interface. 
-      #     OPTIONAL PARAMETER, ONLY SUPPORTED FOR IPVLAN BACKEND
+      #   "proutes": list of policy-based IPv4 routes to be added to the configured routing table of this interface.
+      #     Generally supported parameter, works with all NetworkTypes.
+      #     OPTIONAL PARAMETER
       #     possible value: {"DESTINATION_IPV4_CIDR1:IPV4_GW1","DESTINATION_IPV4_CIDR2:IPV4_GW2"...}
-      #   "proutes6": list of policy-based IPv6 routes to be added to the routing table of this interface.
-      #     OPTIONAL PARAMETER, ONLY SUPPORTED FOR IPVLAN BACKEND
+      #   "proutes6": list of policy-based IPv6 routes to be added to the configured routing table of this interface.
+      #     Generally supported parameter, works with all NetworkTypes.
+      #     OPTIONAL PARAMETER
       #     possible value: {"DESTINATION_IPV6_CIDR1:IPV6_GW1","DESTINATION_IPV6_CIDR2:IPV6_GW2"...}
         danm.k8s.io/interfaces: |
           [


### PR DESCRIPTION
This will enable the creation of MACVLAN interfaces based on the dynamic DanmNet API.
The CNI used to create the interfaces is the basic CNI coming from:
https://github.com/containernetworking/plugins/blob/master/plugins/main/macvlan/macvlan.go

Interfaces are created in bridge mode, with 1500 MTU.

Change is not yet tested.