### PR TITLE
Align the svcwatcher nodeselector

### DIFF
--- a/integration/manifests/svcwatcher/svcwatcher_ds.yaml
+++ b/integration/manifests/svcwatcher/svcwatcher_ds.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
-        nodetype: master
+        "node-role.kubernetes.io/master": ""
       containers:
         - name: svcwatcher
           image: svcwatcher:3.0.0


### PR DESCRIPTION
... for vanilla K8S setup
For clusters created by i.e. kubeadm, the master nodes differentiator label seems to be node-role.kubernetes.io/master without any value.
This change proposed to have this in the sample manifest.