### PR TITLE
Introduce dynamic container interface naming as a fallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ danm        **fakeipam**      host-device  ipvlan       macvlan      ptp        
  ```
 kubectl create -f integration/manifests/netwatcher/
 ```
-Note: we assume RBAC is configured for the Kubernetes API, so the manifests provides the required Role and ServiceAccount for this case.
+Note: we assume RBAC is configured for the Kubernetes API, so the manifests include the required Role and ServiceAccount for this case.
 
 You are now ready to use the services of DANM, and can start bringing-up Pods within your cluster!
 
@@ -231,7 +231,18 @@ Spec:
   Validation:            True
 Events:                  <none>
 ```
-Note: you should always have a network attachment for all your pods, where the Container prefix is `eth0`. Kubelet is always searching for the existence of such Pod interface. If it does not exist after CNI is invoked, the Pod will be re-created in loop.
+##### Naming container interfaces
+Generally speaking, you need to care about how the network interfaces of your Pods are named inside their respective network namespaces.
+The hard reality to keep in mind is that you shall always have an interface literally called "eth0" created within all your Kubernetes Pods, because Kubelet will always search for the existence of such an interface at the end of Pod instantiation.
+If such an interface does not exist after CNI is invoked, the state of the Pod will be considered "faulty", and it will be re-created in a loop.
+To be able to comply with this Kubernetes limitation, DANM supports both explicit, and implicit interface naming schemes!
+
+An interface connected to a DanmNet containing the container_prefix attribute will be always named accordingly. You can use this API to explicitly set descriptive, unique names to NICs connecting to this network.
+In case container_prefix is not set in an interface's network descriptor, DANM will automatically name the interface "ethX", where X is a unique integer number corresponding to the sequence number of the network connection (e.g. the first interface defined in the annotation is called "eth0", second interface "eth1" etc.)
+DANM even supports the mixing of the networking schemes within the same Pod, and it supports the whole naming scheme for all network backends.
+While the feature provides complete control over the name of interfaces, ultimately it is the network administrators' responsibility to:
+ - make sure exactly one interface is named eth0 in every Pod
+ - don't configure multiple NICs into the same Pod with clashing names (e.g. provisioning two implicitly named interfaces, and then a third one explicitly named "eth0", or "eth1" etc.) 
 ##### Delegating to other CNI plugins
 Pay special attention to the DanmNet attribute called "NetworkType". This parameter controls which CNI plugin is invoked by the DANM metaplugin during the execution of a CNI operation to setup, or delete exactly one network interface of a Pod.
 

--- a/integration/crds/DanmNet.yaml
+++ b/integration/crds/DanmNet.yaml
@@ -26,7 +26,6 @@ spec:
               type: string
             Options:
               required:
-              - container_prefix
               - host_device
               - rt_tables
               properties:

--- a/integration/crds/DanmNet.yaml
+++ b/integration/crds/DanmNet.yaml
@@ -25,9 +25,6 @@ spec:
             NetworkType:
               type: string
             Options:
-              required:
-              - host_device
-              - rt_tables
               properties:
                 cidr:
                   type: string

--- a/pkg/crd/apis/danm/v1/types.go
+++ b/pkg/crd/apis/danm/v1/types.go
@@ -116,6 +116,7 @@ type Interface struct {
   Ip6 string `json:"ip6"`
   Proutes map[string]string `json:"proutes"`
   Proutes6 map[string]string `json:"proutes6"`
+  DefaultIfaceName string
 }
 
 type IpamConfig struct {

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -109,7 +109,7 @@ func createContainerIface(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, device s
       return errors.New("Cannot add ip6 address to IPVLAN interface because:" + err.Error())
     }
   }
-  dstPrefix := dnet.Spec.Options.Prefix
+  dstPrefix := ep.Spec.Iface.Name
   err = netlink.LinkSetName(iface, dstPrefix)
   if err != nil {
     return errors.New("cannot rename IPVLAN interface because:" + err.Error())
@@ -270,7 +270,7 @@ func executeArping(srcAddr, ifaceName string) error {
 }
 
 // TODO: Refactor this, as cyclomatic complexity is 15
-func deleteDockerIface(ep danmtypes.DanmEp) error {
+func deleteContainerIface(ep danmtypes.DanmEp) error {
   runtime.LockOSThread()
   defer runtime.UnlockOSThread()
   origns, err := ns.GetCurrentNS()
@@ -320,5 +320,5 @@ func deleteEp(ep danmtypes.DanmEp) error {
   if ns.IsNSorErr(ep.Spec.Netns) != nil {
     return errors.New("Cannot find netns")
   }
-  return deleteDockerIface(ep)
+  return deleteContainerIface(ep)
 }

--- a/pkg/glide.lock
+++ b/pkg/glide.lock
@@ -1,5 +1,5 @@
 hash: c733add746209fb2636606d30af3b2279aa2e51c786422ad39052596bdfc25a1
-updated: 2018-11-30T11:42:22.388805671+01:00
+updated: 2018-12-04T18:31:09.317027749+01:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
@@ -191,6 +191,7 @@ imports:
   version: 7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65
   subpackages:
   - discovery
+  - discovery/fake
   - informers
   - informers/admissionregistration
   - informers/admissionregistration/v1alpha1
@@ -295,6 +296,7 @@ imports:
   - plugin/pkg/client/auth/exec
   - rest
   - rest/watch
+  - testing
   - tools/auth
   - tools/cache
   - tools/clientcmd

--- a/schema/DanmNet.yaml
+++ b/schema/DanmNet.yaml
@@ -33,7 +33,7 @@ spec:
     # Name of the master host device (i.e. physical host NIC).
     # Slave interfaces are connected to this NIC in case NetworkType is set to IPVLAN.
     # A Virtual Function belonging to this Physical Function is taken-up in case NetworkType is set to SRIOV.
-    # MANDATORY - STRING
+    # OPTIONAL - STRING
     host_device: ## MASTER_DEVICE_NAME ##
     # The IPv4 CIDR notation of the subnet associated with the network. 
     # Pods connecting to this network will get their IPs from this subnet, if defined.
@@ -50,7 +50,7 @@ spec:
     # OPTIONAL - STRING
     container_prefix: ## INTERNAL_IF_NAME ##
     # IP routes belonging to this network will be installed in this routing table
-    # MANDATORY - INTEGER (e.g. 201)
+    # OPTIONAL - INTEGER (e.g. 201)
     rt_tables: ## HOST_UNIQUE_ROUTING_TABLE_NUMBER ##
     # IPv4 routes to be installed by default for all containers connected to this network
     # Provisioning L3 IP routes is not supported for SRIOV networks.

--- a/schema/DanmNet.yaml
+++ b/schema/DanmNet.yaml
@@ -45,7 +45,8 @@ spec:
     allocation_pool:
       start: ## FIRST_ASSIGNABLE_IP ##
       end: ## LAST_ASSIGNABLE_IP ##
-    # Interfaces connected to this network will be renamed to "container_prefix" inside the container
+    # Interfaces connected to this network will be renamed to "container_prefix" inside the container.
+    # If not provided, DANM will dynamically allocate a name for each container interface belonging to this network in Pod instantiation time.
     # OPTIONAL - STRING
     container_prefix: ## INTERNAL_IF_NAME ##
     # IP routes belonging to this network will be installed in this routing table


### PR DESCRIPTION
Implements solution to https://github.com/nokia/danm/issues/15
Container_prefix API attribute became optional.
A NIC connecting to a network having it set will continue to be name accordingly.
A NIC connecting to a network not having it set will be dynamically provisioned
a Pod-unique name in Pod Instantiation time.
Enhancement works for in-built IPVLAN, static delegates, and dynamic delegates!