### PR TITLE
RRAC for net and svcwatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ You are now ready to use the services of DANM, and can start bringing-up Pods wi
 
  **+1. OPTIONAL: Create the servicewatcher DaemonSet by executing the following command from the project's root directory:**
  ```
-kubectl create -f integration/manifests/svcwatcher/svcwatcher_ds.yaml
+kubectl create -f integration/manifests/svcwatcher/
 ```
  This component is an optional part of the suite. You only need to install it if you would like to use Kubernetes Services for all the network interfaces of your Pod.
 Note: svcwatcher already leverages DANM CNI to create its network interface. Don't forget to change the name of the network referenced in the example manifest file to one which:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ danm        **fakeipam**      host-device  ipvlan       macvlan      ptp        
  ```
 kubectl create -f integration/manifests/netwatcher/
 ```
-Note: don't forget to change the names of files and directories pointing to valid kubeconfig files, and TLS certificates used by the K8s API server in your infrastructure before instantiating the component! 
+Note: we assume RBAC is configured for the Kubernetes API, so the manifests provides the required Role and ServiceAccount for this case.
 
 You are now ready to use the services of DANM, and can start bringing-up Pods within your cluster!
 
@@ -186,7 +186,7 @@ Note: svcwatcher already leverages DANM CNI to create its network interface. Don
  - exists in your cluster 
  - and through which svcwatcher can reach the Kubernetes API server
  
- We use Flannel for this purpose in our product.
+ We use Flannel for this purpose in our product. We also assume here the RBAC as the API access control method.
 ## User guide
 This section describes what features the DANM networking suite adds to a vanilla Kubernetes environment, and how can users utilize them.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ danm        **fakeipam**      host-device  ipvlan       macvlan      ptp        
 
  **7. Create the netwatcher DaemonSet by executing the following command from the project's root directory:**
  ```
-kubectl create -f integration/manifests/netwatcher/netwatcher_ds.yaml
+kubectl create -f integration/manifests/netwatcher/
 ```
 Note: don't forget to change the names of files and directories pointing to valid kubeconfig files, and TLS certificates used by the K8s API server in your infrastructure before instantiating the component! 
 

--- a/integration/manifests/netwatcher/0netwatcher_rbac.yaml
+++ b/integration/manifests/netwatcher/0netwatcher_rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netwatcher
+  namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:netwatcher
+rules:
+- apiGroups:
+  - "danm.k8s.io"
+  resources:
+  - danmnets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:netwatcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:netwatcher
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: netwatcher
+

--- a/integration/manifests/netwatcher/netwatcher_ds.yaml
+++ b/integration/manifests/netwatcher/netwatcher_ds.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         danm.k8s.io: netwatcher
     spec:
+      serviceAccount: netwatcher
       hostNetwork: true
       dnsPolicy: ClusterFirst
       hostIPC: true
@@ -26,29 +27,9 @@ spec:
                 - SYS_ADMIN
                 - NET_ADMIN
                 - NET_RAW
-          args:
-            - "--kubeconf"
-            - "$(WATCHER_CONFIG)"
-          env:
-            - name: WATCHER_CONFIG
-              value: "/etc/kubernetes/kubeconfig/watcherc.yml"
-          volumeMounts:
-            - name: kubeconf
-              mountPath: /etc/kubernetes/kubeconfig
-              readOnly: true
-            - name: api-server-certs
-              mountPath: /etc/danm/ssl
-              readOnly: true
       tolerations:
        - effect: NoSchedule
          operator: Exists
        - effect: NoExecute
          operator: Exists
       terminationGracePeriodSeconds: 0
-      volumes:
-        - name: kubeconf
-          hostPath:
-            path: /etc/kubernetes/kubeconfig
-        - name: api-server-certs
-          hostPath:
-            path: /etc/danm/ssl

--- a/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
+++ b/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: svcwatcher
+  namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:svcwatcher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - pods
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "danm.k8s.io"
+  resources:
+  - danmnets
+  - danmeps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:svcwatcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:svcwatcher
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: svcwatcher
+

--- a/integration/manifests/svcwatcher/svcwatcher_ds.yaml
+++ b/integration/manifests/svcwatcher/svcwatcher_ds.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         danm.k8s.io: svcwatcher
     spec:
+      serviceAccount: svcwatcher
       dnsPolicy: ClusterFirst
       nodeSelector:
         "node-role.kubernetes.io/master": ""


### PR DESCRIPTION
This PR avoids the usage of hostpath mounts on every node and uses RBAC for the two Danm daemonsets. It allows in-cluster config for kube clients smoothly. The needed role content is reverse engineered and seems working, but please take a look, might be too much or too less still 😇.