### PR TITLE
Default net

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ When network management is delegated to CNI plugins with static integration leve
 Pods can request network connections to DanmNets by defining one or more network connections in the annotation of their (template) spec field, according to the schema described in the **schema/network_attach.yaml** file.
 
 For each connections defined in such a manner DANM will provision exactly one interface into the Pod's network namespace, according to the way described in previous chapters (configuration taken from teh referenced DanmNet API object).
+Note: if the Pod annotation is empty (no danmnet connection is defined), DANM will fall back to use a default network definition, if created. The danmnet object in the target K8S namespace must use the name: "default". It can have any network type (either delegated or ipvlan). Naturally, user in this case cannot specify any further property for the Pod (i.e. static IP address). This way, the user is able to use unmodified manifest files (i.e. community maintained Helm charts or Pods created by K8S operators).
 
 In addition to simply invoking other CNI libraries to set-up network connections, Pod's can even influence the way their interfaces are created to a certain extent.
 For example Pods can ask DANM to provision L3 IP addresses to their IPVLAN or SRI-OV interfaces dnyamically, statically, or not at all!

--- a/pkg/danm/danm.go
+++ b/pkg/danm/danm.go
@@ -72,9 +72,8 @@ func createInterfaces(args *skel.CmdArgs) error {
     return fmt.Errorf("Pod manifest could not be parsed with error: %v", err)
   }
   extractConnections(cniArgs)
-  if len(cniArgs.interfaces) == 0 {
-    log.Println("ERROR: ADD: DANM cannot create interfaces for Pod:" + cniArgs.podId + " , because no network connections are defined in spec.metadata.annotation")
-    return fmt.Errorf("DANM cannot create interfaces for Pod:%s, because no network connections are defined in spec.metadata.annotation", cniArgs.podId)
+  if len(cniArgs.interfaces) == 1 && cniArgs.interfaces[0].Network == defaultNetworkName {
+    log.Println("WARN: ADD: no network connections for Pod: " + cniArgs.podId + " are defined in spec.metadata.annotation. Falling back to use: " + defaultNetworkName)
   }
   cniResult, err := setupNetworking(cniArgs)
   if err != nil {

--- a/pkg/danm/danm.go
+++ b/pkg/danm/danm.go
@@ -32,6 +32,7 @@ var (
   v1Endpoint = "/api/v1/"
   cniVersion = "0.3.1"
   kubeConf string
+  defaultNetworkName = "default"
 )
 
 type NetConf struct {
@@ -174,6 +175,9 @@ func extractConnections(args *cniArgs) error {
       }
       break
     }
+  }
+  if len(ifaces) == 0 {
+    ifaces = []danmtypes.Interface{{Network: defaultNetworkName}}
   }
   args.interfaces = ifaces
   return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
feature

**What does this PR give to us**:
Admin is now able to provision a (single) default network (a danmnet resource with name: "default") in the target kubernetes namespace, which will be used when there is nothing defined in the annotation section of a Pod/Controller.

**Which issue(s) this PR fixes**:
Fixes #21 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Admin is now able to provision a (single) default network (a danmnet resource with name: "default") in the target kubernetes namespace, which will be used when there is nothing defined in the annotation section of a Pod/Controller.
```
