### PR TITLE
Fixing possible 1.13.4 K8s client type incompatibility issue

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,19 +1,20 @@
 #!/bin/sh -ex
-export CGO_ENABLED=0
 export GOOS=linux
 cd $GOPATH/src/github.com/nokia/danm/pkg
 glide install --strip-vendor
 go get -d github.com/vishvananda/netlink
 go get github.com/containernetworking/plugins/pkg/ns
 go get github.com/golang/groupcache/lru
-go get k8s.io/code-generator/cmd/deepcopy-gen
-go get k8s.io/code-generator/cmd/client-gen
-go get k8s.io/code-generator/cmd/lister-gen
-go get k8s.io/code-generator/cmd/informer-gen
-deepcopy-gen -v5 --alsologtostderr --input-dirs github.com/nokia/danm/pkg/crd/apis/danm/v1 -O zz_generated.deepcopy --bounding-dirs github.com/nokia/danm/pkg/crd/apis
-client-gen -v5 --alsologtostderr --clientset-name versioned --input-base "" --input github.com/nokia/danm/pkg/crd/apis/danm/v1 --clientset-path github.com/nokia/danm/pkg/crd/client/clientset
-lister-gen -v5 --alsologtostderr --input-dirs github.com/nokia/danm/pkg/crd/apis/danm/v1 --output-package github.com/nokia/danm/pkg/crd/client/listers
-informer-gen -v5 --alsologtostderr --input-dirs github.com/nokia/danm/pkg/crd/apis/danm/v1 --versioned-clientset-package github.com/nokia/danm/pkg/crd/client/clientset/versioned --listers-package github.com/nokia/danm/pkg/crd/client/listers --output-package github.com/nokia/danm/pkg/crd/client/informers 
+rm -rf $GOPATH/src/k8s.io/code-generator
+git clone -b 'kubernetes-1.13.4' --depth 1 https://github.com/kubernetes/code-generator.git $GOPATH/src/k8s.io/code-generator
+go install k8s.io/code-generator/cmd/deepcopy-gen
+go install k8s.io/code-generator/cmd/client-gen
+go install k8s.io/code-generator/cmd/lister-gen
+go install k8s.io/code-generator/cmd/informer-gen
+deepcopy-gen --alsologtostderr --input-dirs github.com/nokia/danm/pkg/crd/apis/danm/v1 -O zz_generated.deepcopy --bounding-dirs github.com/nokia/danm/pkg/crd/apis
+client-gen --alsologtostderr --clientset-name versioned --input-base "" --input github.com/nokia/danm/pkg/crd/apis/danm/v1 --clientset-path github.com/nokia/danm/pkg/crd/client/clientset
+lister-gen --alsologtostderr --input-dirs github.com/nokia/danm/pkg/crd/apis/danm/v1 --output-package github.com/nokia/danm/pkg/crd/client/listers
+informer-gen --alsologtostderr --input-dirs github.com/nokia/danm/pkg/crd/apis/danm/v1 --versioned-clientset-package github.com/nokia/danm/pkg/crd/client/clientset/versioned --listers-package github.com/nokia/danm/pkg/crd/client/listers --output-package github.com/nokia/danm/pkg/crd/client/informers 
 go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/pkg/danm
 go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/pkg/netwatcher
 go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/pkg/fakeipam

--- a/pkg/crd/apis/danm/v1/types.go
+++ b/pkg/crd/apis/danm/v1/types.go
@@ -25,7 +25,7 @@ type DanmNetSpec struct {
   NetworkID   string        `json:"NetworkID"`
   NetworkType string        `json:"NetworkType,omitempty"`
   Options     DanmNetOption `json:"Options"`
-  Validation  string        `json:"Validation,omitempty"`
+  Validation  bool          `json:"Validation,omitempty"`
 }
 
 type DanmNetOption struct {

--- a/pkg/danmnet/danmnet.go
+++ b/pkg/danmnet/danmnet.go
@@ -64,7 +64,7 @@ func PutDanmNet(client danmclientset.Interface, dnet *danmtypes.DanmNet) (bool,e
 // update validity in apiserver, don't care for 409 (PATCH or PUT)
 // create host specific network stuff: rt_tables, vlan, and vxlan interfaces
 func addDanmNet(client danmclientset.Interface, dn danmtypes.DanmNet) {
-  if dn.Spec.Validation != "" && dn.Spec.Validation == "True" {
+  if dn.Spec.Validation == true {
     err := setupHost(&dn)
     if err != nil {
       log.Println("ERROR: Failed to setup host interfaces for already validated Danmnet:" + dn.Spec.NetworkID +

--- a/pkg/danmnet/net.go
+++ b/pkg/danmnet/net.go
@@ -216,11 +216,11 @@ func deleteHostInterface(ifId int, ifName string) error {
 }
 
 func invalidate(dnet *danmtypes.DanmNet) {
-  dnet.Spec.Validation = "False"
+  dnet.Spec.Validation = false
 }
 
 func validate(dnet *danmtypes.DanmNet) {
-  dnet.Spec.Validation = "True"
+  dnet.Spec.Validation = true
 }
 
 func setupHost(dnet *danmtypes.DanmNet) error {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -26,7 +26,7 @@ const (
 // The reserved IP address is represented by setting a bit in the network's BitArray type allocation matrix
 // The refreshed DanmNet object is modified in the K8s API server at the end
 func Reserve(danmClient danmclientset.Interface, netInfo danmtypes.DanmNet, req4, req6 string) (string, string, string, error) {
-  if strings.ToLower(netInfo.Spec.Validation) != "true" {
+  if netInfo.Spec.Validation != true {
     return "", "", "", errors.New("Invalid network: " + netInfo.Spec.NetworkID)
   }
   tempNetSpec := netInfo

--- a/pkg/ipam_test/ipam_test.go
+++ b/pkg/ipam_test/ipam_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 var testNets = []danmtypes.DanmNet {
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "emptyVal", Validation: ""} },
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "falseValLower", Validation: "false"} },
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "falseValUpper", Validation: "FALSE"} },
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "emptyNet", Validation: "TRUE"} },
+  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "emptyVal", } },
+  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "falseVal", Validation: false} },
+  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "trueVal", Validation: true} },
 }
 
 var reserveTcs = []struct {
@@ -26,9 +25,8 @@ var reserveTcs = []struct {
   isMacExpected bool
 }{
   {"emptyVal", testNets[0], "", "", "", "", true, false},
-  {"falseValLower", testNets[1], "", "", "", "", true, false},
-  {"falseValUpper", testNets[2], "", "", "", "", true, false},
-  {"noIpsRequested", testNets[3], "", "", "", "", false, true},
+  {"falseVal", testNets[1], "", "", "", "", true, false},
+  {"noIpsRequested", testNets[2], "", "", "", "", false, true},
 }
 
 func TestReserve(t *testing.T) {


### PR DESCRIPTION
Automatic conversion between bool and string does not work anymore for some reason with K8s 1.13.4 + latest client generator code, so DanmNet attribute "Validation" cannot be decoded nomo'.
It is anyway stupid to treat it as string, so changed the type in the schema.

But, I had enough of this ... generators on this ... project, so their version is explicitly fixed now in the SCM pipeline.
Unnecessary CGO directive and overly verbose generator log level settings were also removed.

We only had one user sighting of this issue so far, but just in case I create the PR for the fix.
If anyone else see this error in their kubelet logs
"NetworkPlugin cni failed to set up pod "test-danm-dep-5597498784-7rlkh_default" network: CNI network could not be set up: failed to get DanmNet due to:NID:test-net in namespace:default cannot be GET from K8s API server, becuase of error:v1.DanmNet.Spec: v1.DanmNetSpec.Validation: ReadString: expects " or n, but found t, error found in #10 byte of ...|idation":true}}
|..., bigger context ...|refix":"eth","host_device":"ens33"},"Validation":true}}
|...
"
then,
1: keep calm
2: comment on this thread
3: compile danm from this branch
4: .....?
5: PROFIT