### PR TITLE
100% coverage for ipam package - and bugfixes

### DIFF
--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -8,6 +8,7 @@ import (
   "k8s.io/client-go/rest"
   "k8s.io/client-go/tools/cache"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  client "github.com/nokia/danm/crd/client/clientset/versioned/typed/danm/v1"
   danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
   danminformers "github.com/nokia/danm/crd/client/informers/externalversions"
 )
@@ -47,9 +48,9 @@ func (dnetHandler Handler) CreateController() cache.Controller {
   return controller
 }
 
-func PutDanmNet(client danmclientset.Interface, dnet *danmtypes.DanmNet) (bool,error) {
+func PutDanmNet(client client.DanmNetInterface, dnet *danmtypes.DanmNet) (bool,error) {
   var wasResourceAlreadyUpdated bool = false
-  _, err := client.DanmV1().DanmNets(dnet.Namespace).Update(dnet)
+  _, err := client.Update(dnet)
   if err != nil {
     if strings.Contains(err.Error(),danmtypes.OptimisticLockErrorMsg) {
       wasResourceAlreadyUpdated = true
@@ -87,7 +88,8 @@ func addDanmNet(client danmclientset.Interface, dn danmtypes.DanmNet) {
 }
 
 func updateValidity(client danmclientset.Interface, dn *danmtypes.DanmNet) {
-  updateConflicted, err := PutDanmNet(client, dn)
+  netClient := client.DanmV1().DanmNets(dn.ObjectMeta.Namespace)
+  updateConflicted, err := PutDanmNet(netClient, dn)
   if err != nil {
     log.Println("ERROR: Cannot update network:" + dn.Spec.NetworkID + ",err:" + err.Error())
   }

--- a/test/stubs/client_stub.go
+++ b/test/stubs/client_stub.go
@@ -9,10 +9,11 @@ import (
 type ClientStub struct {
   testNets []danmtypes.DanmNet
   testEps []danmtypes.DanmEp
+  reservedIps []ReservedIpsList
 }
 
 func (client *ClientStub) DanmNets(namespace string) client.DanmNetInterface {
-  return newNetClientStub(client.testNets)
+  return newNetClientStub(client.testNets, client.reservedIps)
 }
 
 func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {
@@ -23,9 +24,10 @@ func (c *ClientStub) RESTClient() rest.Interface {
   return nil
 }
 
-func newClientStub(nets []danmtypes.DanmNet, eps []danmtypes.DanmEp ) *ClientStub {
+func newClientStub(nets []danmtypes.DanmNet, eps []danmtypes.DanmEp, ips []ReservedIpsList) *ClientStub {
   return &ClientStub {
     testNets: nets,
     testEps: eps,
+    reservedIps: ips,
   }
 }

--- a/test/stubs/clientset_stub.go
+++ b/test/stubs/clientset_stub.go
@@ -10,6 +10,11 @@ type ClientSetStub struct {
   danmClient *ClientStub
 }
 
+type ReservedIpsList struct {
+  NetworkId string
+  Ips []string
+}
+
 func (c *ClientSetStub) DanmV1() danmv1.DanmV1Interface {
   return c.danmClient
 }
@@ -22,8 +27,8 @@ func (c *ClientSetStub) Discovery() discovery.DiscoveryInterface {
   return nil
 }
 
-func NewClientSetStub(nets []danmtypes.DanmNet, eps []danmtypes.DanmEp) *ClientSetStub {
+func NewClientSetStub(nets []danmtypes.DanmNet, eps []danmtypes.DanmEp, ips []ReservedIpsList) *ClientSetStub {
   var clientSet ClientSetStub
-  clientSet.danmClient = newClientStub(nets, eps)
+  clientSet.danmClient = newClientStub(nets, eps, ips)
   return &clientSet
 }

--- a/test/stubs/clientset_stub.go
+++ b/test/stubs/clientset_stub.go
@@ -12,7 +12,12 @@ type ClientSetStub struct {
 
 type ReservedIpsList struct {
   NetworkId string
-  Ips []string
+  Reservations []Reservation
+}
+
+type Reservation struct {
+  Ip string
+  Set bool
 }
 
 func (c *ClientSetStub) DanmV1() danmv1.DanmV1Interface {

--- a/test/stubs/netclient_stub.go
+++ b/test/stubs/netclient_stub.go
@@ -3,6 +3,7 @@ package stubs
 import (
   "errors"
   "net"
+  "strings"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
   types "k8s.io/apimachinery/pkg/types"
   watch "k8s.io/apimachinery/pkg/watch"
@@ -10,46 +11,73 @@ import (
   "github.com/nokia/danm/pkg/bitarray"
   "github.com/nokia/danm/pkg/netcontrol"
 )
+const (
+  magicVersion = "42"
+)
 
 type NetClientStub struct{
   testNets []danmtypes.DanmNet
   reservedIpsList []ReservedIpsList
 }
 
-func newNetClientStub(nets []danmtypes.DanmNet, ips []ReservedIpsList) NetClientStub {
-  return NetClientStub{testNets: nets, reservedIpsList: ips}
+func newNetClientStub(nets []danmtypes.DanmNet, ips []ReservedIpsList) *NetClientStub {
+  return &NetClientStub{testNets: nets, reservedIpsList: ips}
 }
 
-func (netClient NetClientStub) Create(obj *danmtypes.DanmNet) (*danmtypes.DanmNet, error) {
+func (netClient *NetClientStub) Create(obj *danmtypes.DanmNet) (*danmtypes.DanmNet, error) {
   return nil, nil
 }
 
-func (netClient NetClientStub) Update(obj *danmtypes.DanmNet) (*danmtypes.DanmNet, error) {
-  for _, reservation := range netClient.reservedIpsList {
-    if obj.Spec.NetworkID == reservation.NetworkId {
+func (netClient *NetClientStub) Update(obj *danmtypes.DanmNet) (*danmtypes.DanmNet, error) {
+  for _, netReservation := range netClient.reservedIpsList {
+    if obj.Spec.NetworkID == netReservation.NetworkId {
       ba := bitarray.NewBitArrayFromBase64(obj.Spec.Options.Alloc)
       _, ipnet, _ := net.ParseCIDR(obj.Spec.Options.Cidr)
       ipnetNum := netcontrol.Ip2int(ipnet.IP)
-      for _, ipToBeChecked := range reservation.Ips {
-        ipInInt := netcontrol.Ip2int(net.ParseIP(ipToBeChecked)) - ipnetNum
-        if !ba.Get(uint32(ipInInt)) {
-          return nil, errors.New("Reservation failure, IP:" + ipToBeChecked + " must be reserved in DanmNet:" + obj.Spec.NetworkID)
+      for _, reservation := range netReservation.Reservations {
+        ip,_,err := net.ParseCIDR(reservation.Ip)
+        if err != nil {
+          continue
+        }
+        ipInInt := netcontrol.Ip2int(ip) - ipnetNum
+        if !ipnet.Contains(ip) {
+          continue
+        }
+        if !ba.Get(uint32(ipInInt)) && reservation.Set {
+          return nil, errors.New("Reservation failure, IP:" + reservation.Ip + " must be reserved in DanmNet:" + obj.Spec.NetworkID)
+        }
+        if ba.Get(uint32(ipInInt)) && !reservation.Set {
+          return nil, errors.New("Reservation failure, IP:" + reservation.Ip + " must be free in DanmNet:" + obj.Spec.NetworkID)
         }
       }
     }
   }
+  if strings.Contains(obj.Spec.NetworkID, "conflict") && obj.ObjectMeta.ResourceVersion != magicVersion {
+    for index, net := range netClient.testNets {
+      if net.Spec.NetworkID == obj.Spec.NetworkID {
+        netClient.testNets[index].ObjectMeta.ResourceVersion = magicVersion
+      }
+    }
+    return nil, errors.New(danmtypes.OptimisticLockErrorMsg)
+  }
+  if strings.Contains(obj.Spec.NetworkID, "error") {
+    return nil, errors.New("fatal error, don't retry")
+  }
   return obj, nil
 }
 
-func (netClient NetClientStub) Delete(name string, options *meta_v1.DeleteOptions) error {
+func (netClient *NetClientStub) Delete(name string, options *meta_v1.DeleteOptions) error {
   return nil
 }
 
-func (netClient NetClientStub) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+func (netClient *NetClientStub) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
   return nil
 }
 
-func (netClient NetClientStub) Get(netName string, options meta_v1.GetOptions) (*danmtypes.DanmNet, error) {
+func (netClient *NetClientStub) Get(netName string, options meta_v1.GetOptions) (*danmtypes.DanmNet, error) {
+  if strings.Contains(netName, "error") {
+    return nil, errors.New("fatal error, don't retry")
+  }
   for _, testNet := range netClient.testNets {
     if testNet.Spec.NetworkID == netName {
       return &testNet, nil
@@ -58,19 +86,19 @@ func (netClient NetClientStub) Get(netName string, options meta_v1.GetOptions) (
   return nil, errors.New("let's test error case as well")
 }
 
-func (netClient NetClientStub) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (netClient *NetClientStub) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
   watch := watch.NewEmptyWatch()
   return watch, nil
 }
 
-func (netClient NetClientStub) List(opts meta_v1.ListOptions) (*danmtypes.DanmNetList, error) {
+func (netClient *NetClientStub) List(opts meta_v1.ListOptions) (*danmtypes.DanmNetList, error) {
   return nil, nil
 }
 
-func (netClient NetClientStub) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *danmtypes.DanmNet, err error) {
+func (netClient *NetClientStub) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *danmtypes.DanmNet, err error) {
   return nil, nil
 }
 
-func (netClient NetClientStub) AddReservedIpsList(reservedIps []ReservedIpsList) {
+func (netClient *NetClientStub) AddReservedIpsList(reservedIps []ReservedIpsList) {
   netClient.reservedIpsList = reservedIps
 }

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -62,7 +62,7 @@ var isDeviceNeededTcs = []struct {
 }
 
 func TestIsDelegationRequired(t *testing.T) {
-  netClientStub := stubs.NewClientSetStub(testNets, nil)
+  netClientStub := stubs.NewClientSetStub(testNets, nil, nil)
   for _, tc := range delegationRequiredTcs {
     t.Run(tc.netName, func(t *testing.T) {
       isDelRequired,_,err := cnidel.IsDelegationRequired(netClientStub,tc.netName,"hululululu")

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -55,13 +55,19 @@ var reserveTcs = []struct {
 }
 
 func TestReserve(t *testing.T) {
-  netClientStub := stubs.NewClientSetStub(testNets, nil)
   err := setupAllocationPools(testNets)
   if err != nil {
     t.Errorf("Allocation pool for testnets could not be set-up because:%v", err)
   }
   for _, tc := range reserveTcs {
     t.Run(tc.netName, func(t *testing.T) {
+      var ips []stubs.ReservedIpsList
+      if tc.expectedIp4 != "" {
+        strippedId := strings.Split(tc.expectedIp4, "/")
+        expectedAllocation := stubs.ReservedIpsList{NetworkId: testNets[tc.netIndex].Spec.NetworkID, Ips: []string {strippedId[0],},}
+        ips = append(ips, expectedAllocation)
+      }
+      netClientStub := stubs.NewClientSetStub(testNets, nil, ips)
       ip4, ip6, mac, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         t.Errorf("Received error:%v does not match with expectation", err)

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -1,10 +1,15 @@
 package ipam_test
 
 import (
-  "testing"
+  "log"
+  "net"
   "os"
-  "github.com/nokia/danm/pkg/ipam"
+  "strings"
+  "testing"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/bitarray"
+  "github.com/nokia/danm/pkg/ipam"
+  "github.com/nokia/danm/pkg/netcontrol"
   "github.com/nokia/danm/test/stubs"
 )
 
@@ -12,11 +17,14 @@ var testNets = []danmtypes.DanmNet {
   danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "emptyVal", } },
   danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "falseVal", Validation: false} },
   danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "trueVal", Validation: true} },
+  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "cidr", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}} },
+  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "fullIpv4", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.0/30"}} },
+
 }
 
 var reserveTcs = []struct {
   netName string
-  netInfo danmtypes.DanmNet
+  netIndex int
   requestedIp4 string
   requestedIp6 string
   expectedIp4 string
@@ -24,18 +32,39 @@ var reserveTcs = []struct {
   isErrorExpected bool
   isMacExpected bool
 }{
-  {"emptyVal", testNets[0], "", "", "", "", true, false},
-  {"falseVal", testNets[1], "", "", "", "", true, false},
-  {"noIpsRequested", testNets[2], "", "", "", "", false, true},
+  {"emptyVal", 0, "", "", "", "", true, false},
+  {"falseVal", 1, "", "", "", "", true, false},
+  {"noIpsRequested", 2, "", "", "", "", false, true},
+  {"noneIPv4", 2, "none", "", "", "", false, true},
+  {"noneIPv6", 2, "", "none", "", "", false, true},
+  {"noneDualStack", 2, "none", "none", "", "", false, true},
+  {"dynamicErrorIPv4", 2, "dynamic", "", "", "", true, false},
+  {"dynamicErrorIPv6", 2, "", "dynamic", "", "", true, false},
+  {"dynamicErrorDualStack", 2, "dynamic", "dynamic", "", "", true, false},
+  {"dynamicIPv4Success", 3, "dynamic", "", "192.168.1.65/26", "", false, true},
+  {"dynamicIPv4Exhausted", 4, "dynamic", "", "", "", true, false},
+  {"staticInvalidIPv4", 4, "hululululu", "", "", "", true, false},
+  {"staticInvalidNoCidrIPv4", 4, "192.168.1.1", "", "", "", true, false},
+  {"staticL2IPv4", 2, "192.168.1.1/26", "", "", "", true, false},
+  {"staticNetmaskMismatchIPv4", 4, "192.168.1.1/32", "", "", "", true, false},
+  {"staticAlreadyUsedIPv4", 4, "192.168.1.2/30", "", "", "", true, false},
+  {"staticSuccessLastIPv4", 3, "192.168.1.126/26", "", "192.168.1.126/26", "", false, true},
+  {"staticSuccessFirstIPv4", 3, "192.168.1.65/26", "", "192.168.1.65/26", "", false, true},
+  {"staticFailAfterLastIPv4", 3, "192.168.1.127/26", "", "", "", true, false},
+  {"staticFailBeforeFirstIPv4", 3, "192.168.1.64/26", "", "", "", true, false},
 }
 
 func TestReserve(t *testing.T) {
   netClientStub := stubs.NewClientSetStub(testNets, nil)
+  err := setupAllocationPools(testNets)
+  if err != nil {
+    t.Errorf("Allocation pool for testnets could not be set-up because:%v", err)
+  }
   for _, tc := range reserveTcs {
     t.Run(tc.netName, func(t *testing.T) {
-      ip4, ip6, mac, err := ipam.Reserve(netClientStub, tc.netInfo, tc.requestedIp4, tc.requestedIp6)
+      ip4, ip6, mac, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
-        t.Errorf("Received error:%s does not match with expectation", err.Error())
+        t.Errorf("Received error:%v does not match with expectation", err)
         return
       }
       if tc.isMacExpected {
@@ -51,6 +80,41 @@ func TestReserve(t *testing.T) {
       }
     })
   }
+}
+
+func setupAllocationPools(nets []danmtypes.DanmNet) error {
+  for index, net := range nets {
+    if net.Spec.Options.Cidr != "" {
+      bitArray, err := netcontrol.CreateAllocationArray(&net)
+      if err != nil {
+        return err
+      }
+      net.Spec.Options.Alloc = bitArray.Encode()
+      err = netcontrol.ValidateAllocationPool(&net)
+      if err != nil {
+        return err
+      }
+      if strings.HasPrefix(net.Spec.NetworkID, "full") {
+        log.Println("lofaaaasz before:" + net.Spec.Options.Alloc)
+        exhaustNetwork(&net)
+        log.Println("lofaaaasz after:" + net.Spec.Options.Alloc)
+      }
+      testNets[index].Spec = net.Spec
+    }
+  }
+  return nil
+}
+
+func exhaustNetwork(netInfo *danmtypes.DanmNet) {
+    ba := bitarray.NewBitArrayFromBase64(netInfo.Spec.Options.Alloc)
+    _, ipnet, _ := net.ParseCIDR(netInfo.Spec.Options.Cidr)
+    ipnetNum := netcontrol.Ip2int(ipnet.IP)
+    begin := netcontrol.Ip2int(net.ParseIP(netInfo.Spec.Options.Pool.Start)) - ipnetNum
+    end := netcontrol.Ip2int(net.ParseIP(netInfo.Spec.Options.Pool.End)) - ipnetNum
+    for i:=begin;i<=end;i++ {
+        ba.Set(uint32(i))
+    }
+    netInfo.Spec.Options.Alloc = ba.Encode()
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Bugs caught and corrected during UTing this package:
1: Last IP from the allocation pool was never used
2: When Pool.End was not provided, we set the first IP into this parameter, rather than the last.
This has resulted in failing validation for a subnet providing only CIDR without allocation pool
3: Static IPs were not validated against the allocation pool
4: When the allocation pool is entirely exhausted, we did not explicitly return an error, but let DANM proceed with setting up an interface without an IP. This has been changed now