### PR TITLE
Set IPv6 related sysctls, if at least one IPv6 CIDR is set on any interfaces

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -16,9 +16,10 @@ imports:
   - pkg/types/current
   - pkg/version
 - name: github.com/containernetworking/plugins
-  version: a686cc4bd84f77d93115f6f3e0ec894d55be178e
+  version: a62711a5da7a2dc2eb93eac47e103738ad923fd6
   subpackages:
   - pkg/ns
+  - pkg/utils/sysctl
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
@@ -122,7 +123,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
-  version: 072894a440bdee3a891dea811fe42902311cd2a3
+  version: 2d6f90ab1293a1fb871cf149423ebb72aa7423aa
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
@@ -208,7 +209,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65
+  version: 59698c7d9724b0f95f9dc9e7f7dfdcc3dfeceb82
   subpackages:
   - discovery
   - discovery/fake

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,9 +17,11 @@ ignore:
 - github.com/nokia/danm/pkg/svcwatcher
 import:
 - package: k8s.io/client-go
-  version: v8.0.0
+  version: kubernetes-1.11.1
 - package: github.com/containernetworking/cni
   version: v0.6.0
+- package: github.com/containernetworking/plugins
+  version: v0.7.5
 - package: github.com/intel/multus-cni
   version: 8bf358071ab54b8f38d10027ccf81a29dfb78b3d
 - package: github.com/intel/sriov-cni


### PR DESCRIPTION
**What type of PR is this?**

feature

**What does this PR give to us**:

DANM takes care of IPv6 related sysctls before CNIs are invoked.

**Which issue(s) this PR fixes**:

Fixes #68 

**Special notes for your reviewer**:

Tested with ipvlan inside VMs.

**Does this PR introduce a user-facing change?**:

None.