### PR TITLE
Fixing iface deletion bug when netIds don't match

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,15 @@ __Such action will undoubtedly lead to ruin and DANMation!__
 Generally speaking, you need to care about how the network interfaces of your Pods are named inside their respective network namespaces.
 The hard reality to keep in mind is that you shall always have an interface literally called "eth0" created within all your Kubernetes Pods, because Kubelet will always search for the existence of such an interface at the end of Pod instantiation.
 If such an interface does not exist after CNI is invoked (also having an IPv4 address), the state of the Pod will be considered "faulty", and it will be re-created in a loop.
-To be able to comply with this Kubernetes limitation, DANM supports both explicit, and implicit interface naming schemes for all NetworkTypes!
+To be able to comply with this Kubernetes limitation, DANM always names the first container interface "eth0", regardless of your intention.
+Sorry, but they made us do it :)
 
+However, DANM also supports both explicit, and implicit interface naming schemes for all NetworkTypes to help you flexibly name the other interfaces!
 An interface connected to a DanmNet containing the container_prefix attribute is always named accordingly. You can use this API to explicitly set descriptive, unique names to NICs connecting to this network.
 In case container_prefix is not set in an interface's network descriptor, DANM automatically uses the "eth" as the prefix when naming the interface.
 Regardless which prefix is used, the interface name is also suffixed with an integer number corresponding to the sequence number of the network connection (e.g. the first interface defined in the annotation is called "eth0", second interface "eth1" etc.)
 DANM even supports the mixing of the networking schemes within the same Pod, and it supports the whole naming scheme for all network backends.
 This enables network administrators to even connect Pods to the same network more than once!
-While the feature provides complete control over the name of interfaces, ultimately it is the network administrators' responsibility to make sure exactly one interface is named eth0 in every Pod.
 
 ##### Provisioning static IP routes
 We recognize that not all networking involves an overlay technology, so provisioning IP routes directly into the Pod's network namespace needs to be generally supported.

--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -79,6 +79,7 @@ type DanmEp struct {
 
 type DanmEpSpec struct {
   NetworkID   string      `json:"NetworkID"`
+  NetworkName string      `json:"NetworkName"`
   NetworkType string      `json:"NetworkType"`
   EndpointID  string      `json:"EndpointID"`
   Iface       DanmEpIface `json:"Interface"`
@@ -86,8 +87,6 @@ type DanmEpSpec struct {
   Pod         string      `json:"Pod"`
   CID         string      `json:"CID,omitempty"`
   Netns       string      `json:"netns,omitempty"`
-  Creator     string      `json:"Creator,omitempty"`
-  Expires     string      `json:"Expires,omitempty"`
 }
 
 type DanmEpIface struct {

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -261,6 +261,10 @@ func GetEnv(key, fallback string) string {
 // If a name is explicitly set in the related DanmNet API object, the NIC will be named accordingly.
 // If a name is not explicitly set, then DANM will name the interface ethX where X=sequence number of the interface
 func CalculateIfaceName(chosenName, defaultName string, sequenceId int) string {
+  //Kubelet expects the first interface to be literally named "eth0", so...
+  if sequenceId == 0 {
+    return "eth0"
+  }
   if chosenName != "" {
     return chosenName + strconv.Itoa(sequenceId)
   }

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -257,14 +257,19 @@ func TestCalculateIfaceName(t *testing.T) {
   testDefaultName := "notthechosenone"
   testSequenceId := 4
   expChosenName := testChosenName+strconv.Itoa(testSequenceId)
-  expDefName := testDefaultName+strconv.Itoa(testSequenceId)
   ifaceName := cnidel.CalculateIfaceName(testChosenName, testDefaultName, testSequenceId)
   if ifaceName != expChosenName {
     t.Errorf("Received value for explicitly set interface name: %s does not match with expected: %s", ifaceName, testChosenName)
   }
+  expDefName := testDefaultName+strconv.Itoa(testSequenceId)
   defIfaceName := cnidel.CalculateIfaceName("", testDefaultName, testSequenceId)
   if defIfaceName != expDefName {
     t.Errorf("Received value for default interface name: %s does not match with expected: %s", defIfaceName, testChosenName)
+  }
+  expFirstNicName := "eth0"
+  firstIfaceName := cnidel.CalculateIfaceName(testChosenName, testDefaultName, 0)
+  if firstIfaceName != expFirstNicName {
+    t.Errorf("The first interface shall always be named eth0, regardless what the user wants")
   }
 }
 


### PR DESCRIPTION
The project assumes that a DanmNet's NetworkID and ObjectMeta.Name parameters always match.
This is even outlined in the schema descriptor.
However, recently we have introduced some changes which broke this assumption.
First, with the "default" feature, and then lately with the variable static delegate configuration.
The user might not even perceive it, but as a result of these changes interfaces weren't properly cleaned-up during CNI DEL invocations.
Instead of re-writing the whole codebase, we save the real name of the network as well into the interface's DanmEp, and use this parameter when we read the network descriptor during the deletion of the interface.
Meaning of NetworkID parameter left untouched in all the other places, but eventually, we need to revise when to sue which parameter.

Commit contains one more small,, but important change: the first interface of a Pod will be always named "eth0" from now on.
This change will make it impossible for users to accidentally screw-up network naming, and thus kill their own Pod.
