### PR TITLE
Changing the rest of the codebase to consistently use ObjectMeta.Name

### DIFF
--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -78,7 +78,6 @@ type DanmEp struct {
 }
 
 type DanmEpSpec struct {
-  NetworkID   string      `json:"NetworkID"`
   NetworkName string      `json:"NetworkName"`
   NetworkType string      `json:"NetworkType"`
   EndpointID  string      `json:"EndpointID"`

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -53,7 +53,7 @@ func DelegateInterfaceSetup(danmClient danmclientset.Interface, netInfo *danmtyp
   if isIpamNeeded(netInfo.Spec.NetworkType) {
    ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6, _, err = ipam.Reserve(danmClient, *netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     if err != nil {
-      return nil, errors.New("IP address reservation failed for network:" + netInfo.Spec.NetworkID + " with error:" + err.Error())
+      return nil, errors.New("IP address reservation failed for network:" + netInfo.ObjectMeta.Name + " with error:" + err.Error())
     }
    //TODO: as netInfo is only copied to IPAM above, the IP allocation is not refreshed in the original copy.
    //Therefore, anyone wishing to further update the same DanmNet later on will use an outdated representation as the input.
@@ -62,7 +62,7 @@ func DelegateInterfaceSetup(danmClient danmclientset.Interface, netInfo *danmtyp
    //log.Println("inside cnidel testnet alloc after:" + netInfo.Spec.Options.Alloc)
     ipamOptions, err = getCniIpamConfig(netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     if err != nil {
-      return nil, errors.New("IPAM config creation failed for network:" + netInfo.Spec.NetworkID + " with error:" + err.Error())
+      return nil, errors.New("IPAM config creation failed for network:" + netInfo.ObjectMeta.Name + " with error:" + err.Error())
     }
   }
   rawConfig, err := getCniPluginConfig(netInfo, ipamOptions, ep)
@@ -223,7 +223,7 @@ func freeDelegatedIp(danmClient danmclientset.Interface, netInfo *danmtypes.Danm
   if isIpamNeeded(netInfo.Spec.NetworkType) && ip != "" {
     err := ipam.Free(danmClient, *netInfo, ip)
     if err != nil {
-      return errors.New("cannot give back ip address for NID:" + netInfo.Spec.NetworkID + " addr:" + ip)
+      return errors.New("cannot give back ip address for DanmNet:" + netInfo.ObjectMeta.Name + " addr:" + ip)
     }
   }
   return nil

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -23,14 +23,14 @@ import (
 // The refreshed DanmNet object is modified in the K8s API server at the end
 func Reserve(danmClient danmclientset.Interface, netInfo danmtypes.DanmNet, req4, req6 string) (string, string, string, error) {
   if netInfo.Spec.Validation != true {
-    return "", "", "", errors.New("Invalid network: " + netInfo.Spec.NetworkID)
+    return "", "", "", errors.New("Invalid network: " + netInfo.ObjectMeta.Name)
   }
   tempNetSpec := netInfo
   netClient := danmClient.DanmV1().DanmNets(netInfo.ObjectMeta.Namespace)
   for {
     ip4, ip6, macAddr, err := allocateIP(&tempNetSpec, req4, req6)
     if err != nil {
-      return "", "", "", errors.New("failed to allocate IP address for network:" + netInfo.Spec.NetworkID + " with error:" + err.Error())
+      return "", "", "", errors.New("failed to allocate IP address for network:" + netInfo.ObjectMeta.Name + " with error:" + err.Error())
     }
     retryNeeded, err, newNetSpec := updateDanmNetAllocation(netClient, tempNetSpec)
     if err != nil {
@@ -74,7 +74,7 @@ func updateDanmNetAllocation (netClient client.DanmNetInterface, netInfo danmtyp
     return false, errors.New("DanmNet update failed with error:" + err.Error()), danmtypes.DanmNet{}
   }
   if resourceConflicted {
-    newNetSpec, err := netClient.Get(netInfo.Spec.NetworkID, meta_v1.GetOptions{})
+    newNetSpec, err := netClient.Get(netInfo.ObjectMeta.Name, meta_v1.GetOptions{})
     if err != nil {
       return false, errors.New("After IP address reservation conflict, network cannot be read again!"), danmtypes.DanmNet{}
     }

--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -68,7 +68,7 @@ func addDanmNet(client danmclientset.Interface, dn danmtypes.DanmNet) {
   if dn.Spec.Validation == true {
     err := setupHost(&dn)
     if err != nil {
-      log.Println("ERROR: Failed to setup host interfaces for already validated Danmnet:" + dn.Spec.NetworkID +
+      log.Println("ERROR: Failed to setup host interfaces for already validated Danmnet:" + dn.ObjectMeta.Name +
       " because:" + err.Error())
     }
     return
@@ -91,11 +91,11 @@ func updateValidity(client danmclientset.Interface, dn *danmtypes.DanmNet) {
   netClient := client.DanmV1().DanmNets(dn.ObjectMeta.Namespace)
   updateConflicted, err := PutDanmNet(netClient, dn)
   if err != nil {
-    log.Println("ERROR: Cannot update network:" + dn.Spec.NetworkID + ",err:" + err.Error())
+    log.Println("ERROR: Cannot update network:" + dn.ObjectMeta.Name + ",err:" + err.Error())
   }
   if updateConflicted {
     //Special case: resource was already updated, so this error code can be ignored
-    log.Println("INFO: Network: " + dn.Spec.NetworkID + " is already updated")
+    log.Println("INFO: Network: " + dn.ObjectMeta.Name + " is already updated")
   } 
 }
 

--- a/pkg/svccontrol/controller.go
+++ b/pkg/svccontrol/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) delDanmep(obj interface{}) {
 			glog.Errorf("delDanmEp: selector %s", err)
 			return
 		}
-		if len(selectorMap) == 0 || svcNet != de.Spec.NetworkID || epNew.Namespace != deNs {
+		if len(selectorMap) == 0 || svcNet != de.Spec.NetworkName || epNew.Namespace != deNs {
 			continue
 		}
 		deMap := de.GetLabels()

--- a/pkg/svccontrol/utils.go
+++ b/pkg/svccontrol/utils.go
@@ -68,7 +68,7 @@ func SelectDesMatchLabels(des []*danmv1.DanmEp, selectorMap map[string]string, s
 		} else {
 			deMap := de.GetLabels()
 			deFit = IsContain(deMap, selectorMap)
-			if deFit && de.Spec.NetworkID != svcNet {
+			if deFit && de.Spec.NetworkName != svcNet {
 				deFit = false
 			}
 		}
@@ -124,7 +124,7 @@ func MatchExistingSvc(de *danmv1.DanmEp, servicesList []*corev1.Service) []*core
 		if err != nil {
 			return svcList
 		}
-		if len(selectorMap) == 0 || svcNet != de.Spec.NetworkID || svc.GetNamespace() != deNs {
+		if len(selectorMap) == 0 || svcNet != de.Spec.NetworkName || svc.GetNamespace() != deNs {
 			continue
 		}
 		deMap := de.GetLabels()

--- a/schema/DanmNet.yaml
+++ b/schema/DanmNet.yaml
@@ -12,9 +12,10 @@ metadata:
   # MANDATORY - STRING
   namespace: ## NS_NAME  ##
 spec:
-  # This parameter will be used in application description templates for referring to a desired connection point
-  # Currently this parameter shall exactly match with the name of DanmNet object itself
-  # The parameter also configures which CNI configuration file is to be used if NetworkType points to a static-level CNI backend
+  # This parameter provides a second identifier for DanmNets, and can be used to control a number of API features.
+  # For static delegates, the parameter configures which CNI configuration file is to be used if NetworkType points to a static-level CNI backend.
+  # For dynamic delegates, VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
+  # This allows deployment administrators to separate their own interfaces from others' in a multi-tenant environment, e.g. by setting NetworkID to "name_namespace" value.
   # MANDATORY - STRING
   NetworkID: ## NETWORK_NAME  ##
   # This parameter, if present, denotes which backend willl be used to provision the container interfaces connected to this network.

--- a/schema/DanmService.yaml
+++ b/schema/DanmService.yaml
@@ -19,7 +19,7 @@ metadata:
     # MANDATORY - JSON FORMATTED LIST OF STRING:STRING ASSOCIATIONS (e.g. '{"app":"loadbalancer"},{"type":"sctp"}')
     danm.k8s.io/selector: ## POD_SELECTORS ##
     # When DANM creates an Endpoint for a selected Pod, it will populate it with the selected interface's IP.
-    # The selected interface will be the one which is connected to the DanmNet object named in this attribute.
+    # The selected interface will be the one which is connected to the DanmNet object identified (i.e. matching ObjectMeta.Name) in this attribute.
     # Pods, DanmNets, and Services are all namespaced resources, so an Endpoint is created only if all three are within the same K8s namespace.
     # MANDATORY - STRING
     danm.k8s.io/network: ## NETWORK_SELECTOR ##

--- a/schema/network_attach.yaml
+++ b/schema/network_attach.yaml
@@ -27,7 +27,7 @@ spec:
       # For CNIs with only static integration level, Pod-level overwrite options are ignored even if present.
       # MANDATORY - LIST OF REQUIRED NETWORK INTERFACES
       #   One network connection can have the following attributes:
-      #   "network": NetworkID of the DanmNet to which the interface should be connected to. MANDATORY PARAMETER
+      #   "network": Name of the DanmNet (i.e. ObjectMeta.Name) to which the interface should be connected to. MANDATORY PARAMETER
       #   "ip": desired IPv4 address assigment scheme.
       #     Ignored for non-dynamic NetworkTypes.
       #     OPTIONAL PARAMETER - but either "ip" or "ip6" needs to be present. Presence of either "ip" or "ip6" is MANDATORY

--- a/test/stubs/epclient_stub.go
+++ b/test/stubs/epclient_stub.go
@@ -33,7 +33,7 @@ func (epClient EpClientStub) DeleteCollection(options *meta_v1.DeleteOptions, li
 
 func (epClient EpClientStub) Get(epName string, options meta_v1.GetOptions) (*danmtypes.DanmEp, error) {
   for _, testNet := range epClient.testEps {
-    if testNet.Spec.NetworkID == epName {
+    if testNet.Spec.NetworkName == epName {
       return &testNet, nil
     }
   }

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -8,21 +8,22 @@ import (
   "github.com/nokia/danm/pkg/ipam"
   "github.com/nokia/danm/test/stubs"
   "github.com/nokia/danm/test/utils"
+  meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var testNets = []danmtypes.DanmNet {
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "emptyVal", }},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "falseVal", Validation: false}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "trueVal", Validation: true}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "cidr", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "fullIpv4", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.0/30"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "net6", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64", Cidr: "192.168.1.64/26",}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "smallNet6", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/69"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "conflict", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterror", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "conflictFree", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterrorFree", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
-  danmtypes.DanmNet {Spec: danmtypes.DanmNetSpec{NetworkID: "error", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "emptyVal"},Spec: danmtypes.DanmNetSpec{NetworkID: "emptyVal", }},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "falseVal"},Spec: danmtypes.DanmNetSpec{NetworkID: "falseVal", Validation: false}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "trueVal"},Spec: danmtypes.DanmNetSpec{NetworkID: "trueVal", Validation: true}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "cidr"},Spec: danmtypes.DanmNetSpec{NetworkID: "cidr", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "fullIpv4"},Spec: danmtypes.DanmNetSpec{NetworkID: "fullIpv4", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.0/30"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "net6"},Spec: danmtypes.DanmNetSpec{NetworkID: "net6", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64", Cidr: "192.168.1.64/26",}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "smallNet6"},Spec: danmtypes.DanmNetSpec{NetworkID: "smallNet6", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/69"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflict"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflict", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflicterror"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterror", Validation: true, Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflictFree"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflictFree", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflicterrorFree"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterrorFree", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "error"},Spec: danmtypes.DanmNetSpec{NetworkID: "error", Validation: true, Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
 }
 
 var reserveTcs = []struct {


### PR DESCRIPTION
Continuation of https://github.com/nokia/danm/pull/80
After an impromptu author round-table discussion, it was decided that the whole project shall consistently use ObjectMeta.Name attribute when referring to a DanmNet.

This PR finishes the job.

NetworkID shall control only the following functionality:
- Influence name of VxLAN host interface
- Influence name of VLAN host interface
- Define which CNI config file to be used for a static delegate