### PR TITLE
DANM 4.0 EP3: Validating and mutating Webhook is expanded with new rules to cover the newly introduced APIs

### DIFF
--- a/cmd/cnitest/cnitest.go
+++ b/cmd/cnitest/cnitest.go
@@ -13,8 +13,8 @@ import (
   "github.com/containernetworking/cni/pkg/types/current"
   "github.com/containernetworking/cni/pkg/skel"
   "github.com/containernetworking/cni/pkg/version"
-  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/cnidel"
+  "github.com/nokia/danm/pkg/datastructs"
   "github.com/nokia/danm/pkg/metacni"
 )
 
@@ -135,7 +135,7 @@ func validateMacvlanConfig(receivedCniConfig, expectedCniConfig []byte, tcConf T
     if recMacvlanConf.Ipam.Ips == nil {
       return errors.New("Received MACVLAN CNI config does not contain IPv6 address under ipam section, but it shall!")
     }
-    newIpamConfig := danmtypes.IpamConfig{Type: "fakeipam"}
+    newIpamConfig := datastructs.IpamConfig{Type: "fakeipam"}
     for _,ip := range recMacvlanConf.Ipam.Ips {
       if ip.Version != 6 {
         newIpamConfig.Ips = append(newIpamConfig.Ips,ip)

--- a/cmd/fakeipam/fakeipam.go
+++ b/cmd/fakeipam/fakeipam.go
@@ -8,7 +8,7 @@ import (
   "github.com/containernetworking/cni/pkg/skel"
   "github.com/containernetworking/cni/pkg/types/current"
   "github.com/containernetworking/cni/pkg/version"
-  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/datastructs"
 )
 
 //Fakeipam plugin is a very simple CNI-style IPAM plugin, which prints the received IP allocation information to its output.
@@ -18,7 +18,7 @@ import (
 //At the end, fakeipam will simply regurgitate the IP allocation information originally coming from DANM.
 
 type cniConfig struct {
-  Ipam   danmtypes.IpamConfig `json:"ipam"`
+  Ipam   datastructs.IpamConfig `json:"ipam"`
 }
 
 func reserveIp(args *skel.CmdArgs) error {
@@ -33,19 +33,19 @@ func reserveIp(args *skel.CmdArgs) error {
   return cniRes.Print()
 }
 
-func loadIpamConfig(rawConfig []byte) (danmtypes.IpamConfig,error) {
+func loadIpamConfig(rawConfig []byte) (datastructs.IpamConfig,error) {
   cniConf := cniConfig{}
   err := json.Unmarshal(rawConfig, &cniConf)
   if  err != nil {
-    return danmtypes.IpamConfig{}, err
+    return datastructs.IpamConfig{}, err
   }
   if len(cniConf.Ipam.Ips) == 0 {
-    return danmtypes.IpamConfig{}, errors.New("No IP was passed to fake IPAM")
+    return datastructs.IpamConfig{}, errors.New("No IP was passed to fake IPAM")
   }
   return cniConf.Ipam, nil
 }
 
-func createCniResult(ipamConf danmtypes.IpamConfig) (*current.Result,error) {
+func createCniResult(ipamConf datastructs.IpamConfig) (*current.Result,error) {
   var resultIPs = []*current.IPConfig{}
   for _, ipamIp := range ipamConf.Ips {
     ip, ipNet, err := net.ParseCIDR(ipamIp.IpCidr)

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -25,7 +25,8 @@ func main() {
     log.Println("ERROR: TLS configuration could not be initialized, because:" + err.Error())
     return
   }
-  http.HandleFunc("/webhook", netadmit.ValidateNetwork)
+  http.HandleFunc("/netvalidation", netadmit.ValidateNetwork)
+  http.HandleFunc("/confvalidation", netadmit.ValidateTenantConfig)
   server := &http.Server{
     Addr:         *address + ":" + strconv.Itoa(*port),
     TLSConfig:    &tls.Config{Certificates: []tls.Certificate{tlsConf}},

--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -21,9 +21,10 @@ type DanmNet struct {
 }
 
 type DanmNetSpec struct {
-  NetworkID   string        `json:"NetworkID"`
-  NetworkType string        `json:"NetworkType,omitempty"`
-  Options     DanmNetOption `json:"Options,omitempty"`
+  NetworkID   string         `json:"NetworkID"`
+  NetworkType string         `json:"NetworkType,omitempty"`
+  AllowedTenants []string    `json:"AllowedTenants,omitempty"`
+  Options     DanmNetOption  `json:"Options,omitempty"`
 }
 
 type DanmNetOption struct {

--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -4,14 +4,6 @@ import (
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-  OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
-)
-
-type CniBackend struct {
-  CNIVersion string
-}
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type DanmNet struct {
@@ -29,13 +21,13 @@ type DanmNetSpec struct {
 
 type DanmNetOption struct {
   // The device to where the network is attached
-  Device string  `json:"host_device"`
+  Device string  `json:"host_device,omitempty"`
   // The resource_pool contains allocated device IDs
   DevicePool string  `json:"device_pool,omitempty"`
   // the vxlan id on the host device (creation of vxlan interface)
   Vxlan  int  `json:"vxlan,omitempty"`
   // The name of the interface in the container
-  Prefix string  `json:"container_prefix"`
+  Prefix string  `json:"container_prefix,omitempty"`
   // IPv4 specific parameters
   // IPv4 network address
   Cidr   string  `json:"cidr,omitempty"`
@@ -51,7 +43,7 @@ type DanmNetOption struct {
   // IPv6 routes for this network
   Routes6 map[string]string  `json:"routes6,omitempty"`
   // Routing table number for policy routing
-  RTables int `json:"rt_tables"`
+  RTables int `json:"rt_tables,omitempty"`
   // the VLAN id of the VLAN interface created on top of the host device
   Vlan  int  `json:"vlan,omitempty"`
 }
@@ -104,27 +96,25 @@ type DanmEpList struct {
   Items            []DanmEp `json:"items"`
 }
 
-// Interface represents a request coming from the Pod to connect it to one DanmNet during CNI_ADD operation
-// It contains the name of the DanmNet the Pod should be connected to, and other optional requests
-// Pods can influence the scheme of IP allocation (dynamic, static, none),
-// and can ask for the provisioning of policy-based IP routes
-type Interface struct {
-  Network string `json:"network"`
-  Ip string `json:"ip"`
-  Ip6 string `json:"ip6"`
-  Proutes map[string]string `json:"proutes"`
-  Proutes6 map[string]string `json:"proutes6"`
-  DefaultIfaceName string
-  Device string `json:"Device,omitempty"`
-  SequenceId int
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type TenantConfig struct {
+  meta_v1.TypeMeta              `json:",inline"`
+  meta_v1.ObjectMeta            `json:"metadata"`
+  HostDevices []IfaceProfile    `json:"hostDevices"`
+  NetworkIds  map[string]string `json:"networkIds,omitempty"`
 }
 
-type IpamConfig struct {
-  Type      string      `json:"type"`
-  Ips       []IpamIp    `json:"ips,omitempty"`
+type IfaceProfile struct {
+  Name      string `json:"name"`
+  VniType   string `json:"vniType,omitempty"`
+  VniRange  string `json:"vniRange,omitempty"`
+  Alloc     string  `json:"alloc,omitempty"`
 }
 
-type IpamIp struct {
-  IpCidr    string      `json:"ipcidr"`
-  Version   int         `json:"version"`
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type TenantConfigList struct {
+  meta_v1.TypeMeta `json:",inline"`
+  meta_v1.ListMeta `json:"metadata"`
+  Items            []TenantConfig `json:"items"`
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7944d7fcb1c247ee8568840a7669f2f6c32db3753bff819f508868cf09cddbcc
-updated: 2019-05-23T17:30:38.180823311+02:00
+updated: 2019-05-24T17:43:48.928763287+02:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
@@ -342,8 +342,17 @@ imports:
   - util/integer
   - util/retry
   - util/workqueue
+- name: k8s.io/klog
+  version: 8e90cee79f823779174776412c13478955131846
 - name: k8s.io/kube-openapi
   version: 91cfa479c814065e420cee7ed227db0f63a5854e
   subpackages:
   - pkg/util/proto
+- name: k8s.io/kubernetes
+  version: ddf47ac13c1a9483ea035a79cd7c10005ff21a6d
+  subpackages:
+  - pkg/kubelet/apis/podresources
+  - pkg/kubelet/apis/podresources/v1alpha1
+  - pkg/kubelet/cm/cpuset
+  - pkg/kubelet/util
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 51ed68e34f4094e85e86be61e548211603a7e4d02c1591697029130768c5f305
-updated: 2019-04-25T12:41:14.02648742+02:00
+hash: 7944d7fcb1c247ee8568840a7669f2f6c32db3753bff819f508868cf09cddbcc
+updated: 2019-05-23T17:30:38.180823311+02:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
@@ -16,7 +16,7 @@ imports:
   - pkg/types/current
   - pkg/version
 - name: github.com/containernetworking/plugins
-  version: a62711a5da7a2dc2eb93eac47e103738ad923fd6
+  version: 0950a3607bf5e8a57c6a655c7e573e6aab0dc650
   subpackages:
   - pkg/ns
   - pkg/utils/sysctl
@@ -66,13 +66,13 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/intel/multus-cni
-  version: 8bf358071ab54b8f38d10027ccf81a29dfb78b3d
+  version: e723aabca8792ddd181167660e252a127a81b073
   subpackages:
   - checkpoint
   - logging
   - types
 - name: github.com/intel/sriov-cni
-  version: a87cb21e2f4aadedec7021eefa45523af51071ac
+  version: 9e4c973b2ac517c64867e33d61aee152d70dc330
   subpackages:
   - pkg/utils
 - name: github.com/j-keck/arping
@@ -96,7 +96,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - context
   - context/ctxhttp
@@ -125,8 +125,9 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
-  version: 2d6f90ab1293a1fb871cf149423ebb72aa7423aa
+  version: f1b257a4ce9632d2f06a58c3417d1523149bc94d
   subpackages:
+  - admission/v1beta1
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
   - apps/v1
@@ -158,7 +159,7 @@ imports:
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 103fd098999dc9c0c88536f5c9ad2e5da39373ae
+  version: c182ff3b98419e7305cc361fd1811988591656cf
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -211,7 +212,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 59698c7d9724b0f95f9dc9e7f7dfdcc3dfeceb82
+  version: 3ec0d5188431b312d6b3d5b6e46e022d5c0843a4
   subpackages:
   - discovery
   - discovery/fake

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,13 +11,13 @@ ignore:
 - github.com/nokia/danm/pkg/syncher
 import:
 - package: k8s.io/client-go
-  version: kubernetes-1.11.1
+  version: kubernetes-1.11.10
 - package: github.com/containernetworking/cni
   version: v0.6.0
 - package: github.com/containernetworking/plugins
-  version: v0.7.5
+  version: v0.8.0
 - package: github.com/intel/multus-cni
-  version: 8bf358071ab54b8f38d10027ccf81a29dfb78b3d
+  version: e723aabca8792ddd181167660e252a127a81b073
 - package: github.com/intel/sriov-cni
-  version: a87cb21e2f4aadedec7021eefa45523af51071ac
+  version: 9e4c973b2ac517c64867e33d61aee152d70dc330
 

--- a/integration/manifests/webhook/webhook.yaml
+++ b/integration/manifests/webhook/webhook.yaml
@@ -5,19 +5,33 @@ metadata:
   name: danm-webhook-config
   namespace: kube-system
 webhooks:
-  - name: danm-webhook.nokia.k8s.io
+  - name: danm-netvalidation.nokia.k8s.io
     clientConfig:
       service:
         name: danm-webhook-svc
         namespace: kube-system
-        path: "/webhook"
+        path: "/netvalidation"
       # Configure your pre-generated certificate matching the details of your environment
       caBundle: <CA_BUNDLE>
     rules:
       - operations: ["CREATE","UPDATE"]
         apiGroups: ["danm.k8s.io"]
         apiVersions: ["v1"]
-        resources: ["danmnets"]
+        resources: ["danmnets","clusterneworks","tenantnetworks"]
+    failurePolicy: Fail
+  - name: danm-configvalidation.nokia.k8s.io
+    clientConfig:
+      service:
+        name: danm-webhook-svc
+        namespace: kube-system
+        path: "/confvalidation"
+      # Configure your pre-generated certificate matching the details of your environment
+      caBundle: <CA_BUNDLE>
+    rules:
+      - operations: ["CREATE","UPDATE"]
+        apiGroups: ["danm.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["tenantconfigs"]
     failurePolicy: Fail
 ---
 apiVersion: v1

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -6,13 +6,14 @@ import (
   "io/ioutil"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/danmep"
+  "github.com/nokia/danm/pkg/datastructs"
   sriov_utils "github.com/intel/sriov-cni/pkg/utils"
 )
 
 var (
   supportedNativeCnis = map[string]*cniBackendConfig {
     "sriov": &cniBackendConfig {
-      CniBackend: danmtypes.CniBackend {
+      CniBackend: datastructs.CniBackend {
         CNIVersion: "0.3.1",
       },
       readConfig: cniConfigReader(getSriovCniConfig),
@@ -20,7 +21,7 @@ var (
       deviceNeeded: true,
     },
     "macvlan": &cniBackendConfig {
-      CniBackend: danmtypes.CniBackend {
+      CniBackend: datastructs.CniBackend {
         CNIVersion: "0.3.1",
       },
       readConfig: cniConfigReader(getMacvlanCniConfig),
@@ -42,7 +43,7 @@ func readCniConfigFile(cniconfDir string, netInfo *danmtypes.DanmNet) ([]byte, e
 }
 
 //This function creates CNI configuration for the dynamic-level SR-IOV backend
-func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error) {
+func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions datastructs.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error) {
   var sriovConfig SriovNet
   // initialize common fields of "github.com/containernetworking/cni/pkg/types".NetConf
   sriovConfig.CNIVersion = cniVersion
@@ -69,7 +70,7 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamCon
 }
 
 //This function creates CNI configuration for the dynamic-level MACVLAN backend
-func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions danmtypes.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error) {
+func getMacvlanCniConfig(netInfo *danmtypes.DanmNet, ipamOptions datastructs.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error) {
   var macvlanConfig MacvlanNet
   // initialize common fields of "github.com/containernetworking/cni/pkg/types".NetConf
   macvlanConfig.CNIVersion = cniVersion

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -3,12 +3,13 @@ package cnidel
 import (
   "github.com/containernetworking/cni/pkg/types"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/datastructs"
 )
 
-type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam danmtypes.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error)
+type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam datastructs.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error)
 
 type cniBackendConfig struct {
-  danmtypes.CniBackend
+  datastructs.CniBackend
   readConfig cniConfigReader
   ipamNeeded bool
   deviceNeeded bool
@@ -24,7 +25,7 @@ type SriovNet struct {
   // VLAN ID to assign for the VF
   Vlan   int        `json:"vlan,omitEmpty"`
   // IPAM configuration to be used for this network
-  Ipam   danmtypes.IpamConfig `json:"ipam,omitEmpty"`
+  Ipam   datastructs.IpamConfig `json:"ipam,omitEmpty"`
   // Device PCI ID
   DeviceID string `json:"deviceID"`
 }
@@ -45,5 +46,5 @@ type MacvlanNet struct {
   //MTU to be set to the MACVLAN slave interface (default 1500)
   MTU    int    `json:"mtu"`
   //IPAM configuration to be used for this network
-  Ipam   danmtypes.IpamConfig `json:"ipam,omitEmpty"`
+  Ipam   datastructs.IpamConfig `json:"ipam,omitEmpty"`
 }

--- a/pkg/datastructs/datastructs.go
+++ b/pkg/datastructs/datastructs.go
@@ -4,9 +4,42 @@ import (
   "github.com/containernetworking/cni/pkg/types"
 )
 
+const (
+  OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
+)
+
 type NetConf struct {
   types.NetConf
   Kubeconfig   string `json:"kubeconfig"`
   CniConfigDir string `json:"cniDir"`
   NamingScheme string `json:"namingScheme"`
+}
+
+type CniBackend struct {
+  CNIVersion string
+}
+
+// Interface represents a request coming from the Pod to connect it to one DanmNet during CNI_ADD operation
+// It contains the name of the DanmNet the Pod should be connected to, and other optional requests
+// Pods can influence the scheme of IP allocation (dynamic, static, none),
+// and can ask for the provisioning of policy-based IP routes
+type Interface struct {
+  Network string `json:"network"`
+  Ip string `json:"ip"`
+  Ip6 string `json:"ip6"`
+  Proutes map[string]string `json:"proutes"`
+  Proutes6 map[string]string `json:"proutes6"`
+  DefaultIfaceName string
+  Device string `json:"Device,omitempty"`
+  SequenceId int
+}
+
+type IpamConfig struct {
+  Type      string      `json:"type"`
+  Ips       []IpamIp    `json:"ips,omitempty"`
+}
+
+type IpamIp struct {
+  IpCidr    string      `json:"ipcidr"`
+  Version   int         `json:"version"`
 }

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -61,7 +61,7 @@ type cniArgs struct {
   podId string
   containerId string
   stdIn []byte
-  interfaces []danmtypes.Interface
+  interfaces []datastructs.Interface
   pod *core_v1.Pod
 }
 
@@ -168,7 +168,7 @@ func createK8sClient(kubeconfig string) (kubernetes.Interface, error) {
 }
 
 func extractConnections(args *cniArgs) error {
-  var ifaces []danmtypes.Interface
+  var ifaces []datastructs.Interface
   for key, val := range args.pod.Annotations {
     if strings.Contains(key, danmIfDefinitionSyntax) {
       err := json.Unmarshal([]byte(val), &ifaces)
@@ -179,7 +179,7 @@ func extractConnections(args *cniArgs) error {
     }
   }
   if len(ifaces) == 0 {
-    ifaces = []danmtypes.Interface{{Network: defaultNetworkName}}
+    ifaces = []datastructs.Interface{{Network: defaultNetworkName}}
   }
   args.interfaces = ifaces
   return nil
@@ -279,7 +279,7 @@ func setupNetworking(args *cniArgs) (*current.Result, error) {
   return syncher.MergeCniResults(), err
 }
 
-func createDelegatedInterface(syncher *syncher.Syncher, danmClient danmclientset.Interface, iface danmtypes.Interface, netInfo *danmtypes.DanmNet, args *cniArgs) {
+func createDelegatedInterface(syncher *syncher.Syncher, danmClient danmclientset.Interface, iface datastructs.Interface, netInfo *danmtypes.DanmNet, args *cniArgs) {
   epIfaceSpec := danmtypes.DanmEpIface {
     Name:        cnidel.CalculateIfaceName(DanmConfig.NamingScheme, netInfo.Spec.Options.Prefix, iface.DefaultIfaceName, iface.SequenceId),
     Address:     iface.Ip,
@@ -311,7 +311,7 @@ func createDelegatedInterface(syncher *syncher.Syncher, danmClient danmclientset
   syncher.PushResult(netInfo.ObjectMeta.Name, nil, delegatedResult)
 }
 
-func createDanmInterface(syncher *syncher.Syncher, danmClient danmclientset.Interface, iface danmtypes.Interface, netInfo *danmtypes.DanmNet, args *cniArgs) {
+func createDanmInterface(syncher *syncher.Syncher, danmClient danmclientset.Interface, iface datastructs.Interface, netInfo *danmtypes.DanmNet, args *cniArgs) {
   ip4, ip6, macAddr, err := ipam.Reserve(danmClient, *netInfo, iface.Ip, iface.Ip6)
   if err != nil {
     syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("IP address reservation failed for network:" + netInfo.ObjectMeta.Name + " with error:" + err.Error()), nil)

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -17,7 +17,6 @@ import (
   "github.com/containernetworking/plugins/pkg/utils/sysctl"
   core_v1 "k8s.io/api/core/v1"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-//  k8s "k8s.io/apimachinery/pkg/types"
   "k8s.io/client-go/rest"
   "k8s.io/client-go/tools/clientcmd"
   "k8s.io/client-go/kubernetes"

--- a/pkg/netadmit/validators.go
+++ b/pkg/netadmit/validators.go
@@ -2,16 +2,14 @@ package netadmit
 
 import (
   "errors"
-  "log"
   "net"
-  "strconv"
   "encoding/binary"
   admissionv1 "k8s.io/api/admission/v1beta1"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/ipam"
 )
 
-type Validator func(netInfo *danmtypes.DanmNet, opType admissionv1.Operation) error
+type Validator func(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error
 
 type ValidatorMapping []Validator
 
@@ -31,12 +29,12 @@ var (
   }
 )
 
-func validateIpv4Fields(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  return validateIpFields(dnet.Spec.Options.Cidr, dnet.Spec.Options.Routes)
+func validateIpv4Fields(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  return validateIpFields(newManifest.Spec.Options.Cidr, newManifest.Spec.Options.Routes)
 }
 
-func validateIpv6Fields(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  return validateIpFields(dnet.Spec.Options.Net6, dnet.Spec.Options.Routes6)
+func validateIpv6Fields(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  return validateIpFields(newManifest.Spec.Options.Net6, newManifest.Spec.Options.Routes6)
 }
 
 func validateIpFields(cidr string, routes map[string]string) error {
@@ -58,13 +56,13 @@ func validateIpFields(cidr string, routes map[string]string) error {
   return nil
 }
 
-func validateAllocationPool(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  if opType == admissionv1.Create && dnet.Spec.Options.Alloc != "" {
+func validateAllocationPool(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  if opType == admissionv1.Create && newManifest.Spec.Options.Alloc != "" {
     return errors.New("Allocation bitmask shall not be manually defined upon creation!")  
   }
-  cidr := dnet.Spec.Options.Cidr
+  cidr := newManifest.Spec.Options.Cidr
   if cidr == "" {
-    if dnet.Spec.Options.Pool.Start != "" || dnet.Spec.Options.Pool.End != "" {
+    if newManifest.Spec.Options.Pool.Start != "" || newManifest.Spec.Options.Pool.End != "" {
       return errors.New("Allocation pool cannot be defined without CIDR!")
     }
     return nil
@@ -73,18 +71,17 @@ func validateAllocationPool(dnet *danmtypes.DanmNet, opType admissionv1.Operatio
   if err != nil {
     return errors.New("Invalid CIDR parameter: " + cidr)
   }
-  if dnet.Spec.Options.Pool.Start == "" {
-    dnet.Spec.Options.Pool.Start = (ipam.Int2ip(ipam.Ip2int(ipnet.IP) + 1)).String()
+  if newManifest.Spec.Options.Pool.Start == "" {
+    newManifest.Spec.Options.Pool.Start = (ipam.Int2ip(ipam.Ip2int(ipnet.IP) + 1)).String()
   }
-  if dnet.Spec.Options.Pool.End == "" {
-    dnet.Spec.Options.Pool.End = (ipam.Int2ip(ipam.Ip2int(GetBroadcastAddress(ipnet)) - 1)).String()
+  if newManifest.Spec.Options.Pool.End == "" {
+    newManifest.Spec.Options.Pool.End = (ipam.Int2ip(ipam.Ip2int(GetBroadcastAddress(ipnet)) - 1)).String()
   }
-  if !ipnet.Contains(net.ParseIP(dnet.Spec.Options.Pool.Start)) || !ipnet.Contains(net.ParseIP(dnet.Spec.Options.Pool.End)) {
+  if !ipnet.Contains(net.ParseIP(newManifest.Spec.Options.Pool.Start)) || !ipnet.Contains(net.ParseIP(newManifest.Spec.Options.Pool.End)) {
     return errors.New("Allocation pool is outside of defined CIDR")
   }
-  log.Println("End IP:" + strconv.FormatUint(uint64(ipam.Ip2int(net.ParseIP(dnet.Spec.Options.Pool.End))),10) + " Start IP:" + strconv.FormatUint(uint64(ipam.Ip2int(net.ParseIP(dnet.Spec.Options.Pool.Start))),10))
-  if ipam.Ip2int(net.ParseIP(dnet.Spec.Options.Pool.End)) <= ipam.Ip2int(net.ParseIP(dnet.Spec.Options.Pool.Start)) {
-    return errors.New("Allocation pool start:" + dnet.Spec.Options.Pool.Start + " is bigger than or equal to allocation pool end:" + dnet.Spec.Options.Pool.End)
+  if ipam.Ip2int(net.ParseIP(newManifest.Spec.Options.Pool.End)) <= ipam.Ip2int(net.ParseIP(newManifest.Spec.Options.Pool.Start)) {
+    return errors.New("Allocation pool start:" + newManifest.Spec.Options.Pool.Start + " is bigger than or equal to allocation pool end:" + newManifest.Spec.Options.Pool.End)
   }
   return nil
 }
@@ -96,35 +93,44 @@ func GetBroadcastAddress(subnet *net.IPNet) (net.IP) {
   return ip
 }
 
-func validateVids(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  isVlanDefined := (dnet.Spec.Options.Vlan!=0)
-  isVxlanDefined := (dnet.Spec.Options.Vxlan!=0)
+func validateVids(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  isVlanDefined := (newManifest.Spec.Options.Vlan!=0)
+  isVxlanDefined := (newManifest.Spec.Options.Vxlan!=0)
   if isVlanDefined && isVxlanDefined {
     return errors.New("VLAN ID and VxLAN ID parameters are mutually exclusive")
   }
   return nil
 }
 
-func validateNetworkId(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  if dnet.Spec.NetworkID == "" {
+func validateNetworkId(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  if newManifest.Spec.NetworkID == "" {
     return errors.New("Spec.NetworkID mandatory parameter is missing!")
   }
-  if len(dnet.Spec.NetworkID) > MaxNidLength {
+  if len(newManifest.Spec.NetworkID) > MaxNidLength {
     return errors.New("Spec.NetworkID cannot be longer than 12 characters (otherwise VLAN and VxLAN host interface creation might fail)!")
   }
   return nil
 }
 
-func validateAbsenceOfAllowedTenants(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  if dnet.Spec.AllowedTenants != nil {
+func validateAbsenceOfAllowedTenants(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  if newManifest.Spec.AllowedTenants != nil {
     return errors.New("AllowedTenants attribute is only valid for the ClusterNetwork API!")
   }
   return nil
 }
 
-func validateTenantNetRules(dnet *danmtypes.DanmNet, opType admissionv1.Operation) error {
-  if dnet.Spec.Options.Device != "" || dnet.Spec.Options.Vxlan != 0 || dnet.Spec.Options.Vlan != 0 {
-    return errors.New("Manually configuring host_device, vlan, or attributes is not allowed for TenantNetworks!")  
+func validateTenantNetRules(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
+  if opType == admissionv1.Create && 
+    (newManifest.Spec.Options.Device != "" ||
+     newManifest.Spec.Options.Vxlan  != 0  ||
+     newManifest.Spec.Options.Vlan   != 0) {
+    return errors.New("Manually configuring any one of host_device, vlan, or vxlan attributes is not allowed for TenantNetworks!")  
+  }
+  if opType == admissionv1.Update && 
+    (newManifest.Spec.Options.Device  != oldManifest.Spec.Options.Device  || 
+     newManifest.Spec.Options.Vxlan   != oldManifest.Spec.Options.Vxlan   ||
+     newManifest.Spec.Options.Vlan    != oldManifest.Spec.Options.Vlan) {
+    return errors.New("Manually changing any one of host_device, vlan, or vxlan attributes is not allowed for TenantNetworks!")  
   }
   return nil
 }

--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -11,6 +11,7 @@ import (
   client "github.com/nokia/danm/crd/client/clientset/versioned/typed/danm/v1"
   danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
   danminformers "github.com/nokia/danm/crd/client/informers/externalversions"
+  "github.com/nokia/danm/pkg/datastructs"
 )
 
 // Handler represents an object watching the K8s API for changes in the DanmNet API path
@@ -52,7 +53,7 @@ func PutDanmNet(client client.DanmNetInterface, dnet *danmtypes.DanmNet) (bool,e
   var wasResourceAlreadyUpdated bool = false
   _, err := client.Update(dnet)
   if err != nil {
-    if strings.Contains(err.Error(),danmtypes.OptimisticLockErrorMsg) {
+    if strings.Contains(err.Error(),datastructs.OptimisticLockErrorMsg) {
       wasResourceAlreadyUpdated = true
       return wasResourceAlreadyUpdated, nil
     }

--- a/pkg/svccontrol/controller.go
+++ b/pkg/svccontrol/controller.go
@@ -194,7 +194,7 @@ func (c *Controller) UpdateEndpoints(eps *corev1.Endpoints) {
 	if len(eps.Subsets[0].Addresses) == 0 && len(eps.Subsets[0].NotReadyAddresses) == 0 {
 		eps.Subsets = nil
 	}
-	_, err := c.kubeclient.Core().Endpoints(eps.Namespace).Update(eps)
+	_, err := c.kubeclient.CoreV1().Endpoints(eps.Namespace).Update(eps)
 	if err != nil {
 		glog.Errorf("danmep: updateEndpoints: %s\n%s", err, eps)
 	}
@@ -209,9 +209,9 @@ func (c *Controller) UpdateEndpointsList(epList []*corev1.Endpoints) {
 func (c *Controller) CreateModifyEndpoints(svc *corev1.Service, ep bool, des []*danmv1.DanmEp) {
 	epNew := c.MakeNewEps(svc, des)
     	if ep {
-		c.kubeclient.Core().Endpoints(svc.Namespace).Update(&epNew)
+		c.kubeclient.CoreV1().Endpoints(svc.Namespace).Update(&epNew)
 	} else {
-		c.kubeclient.Core().Endpoints(svc.Namespace).Create(&epNew)
+		c.kubeclient.CoreV1().Endpoints(svc.Namespace).Create(&epNew)
 	}
 }
 

--- a/test/stubs/client_stub.go
+++ b/test/stubs/client_stub.go
@@ -20,6 +20,10 @@ func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {
   return newEpClientStub(client.testEps)
 }
 
+func (client *ClientStub) TenantConfigs(namespace string) client.TenantConfigInterface {
+  return nil
+}
+
 func (c *ClientStub) RESTClient() rest.Interface {
   return nil
 }

--- a/test/stubs/netclient_stub.go
+++ b/test/stubs/netclient_stub.go
@@ -9,6 +9,7 @@ import (
   watch "k8s.io/apimachinery/pkg/watch"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/bitarray"
+  "github.com/nokia/danm/pkg/datastructs"
   "github.com/nokia/danm/pkg/ipam"
 )
 const (
@@ -58,7 +59,7 @@ func (netClient *NetClientStub) Update(obj *danmtypes.DanmNet) (*danmtypes.DanmN
         netClient.testNets[index].ObjectMeta.ResourceVersion = magicVersion
       }
     }
-    return nil, errors.New(danmtypes.OptimisticLockErrorMsg)
+    return nil, errors.New(datastructs.OptimisticLockErrorMsg)
   }
   if strings.Contains(obj.Spec.NetworkID, "error") {
     return nil, errors.New("fatal error, don't retry")


### PR DESCRIPTION
Fortunately it is pretty slick thanks to the generic validating structure introduced in EP1.

Existing validating rules, and the validating interface itself was updated to be able to define separate rules for MODIFY operations. This was a must have for TenantNetworks, but also comes handy in the validation of spec.Options.Alloc.

Still need to figure out the best way of adding TenantConfigs to the generic framework. 