### PR TITLE
DANM 4.0 EP5: Adapting netwatcher to create VLAN and VxLAN interfaces for all APIs

### DIFF
--- a/crd/apis/danm/v1/register.go
+++ b/crd/apis/danm/v1/register.go
@@ -32,6 +32,10 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&DanmEpList{},
 		&DanmNet{},
 		&DanmNetList{},
+		&ClusterNetwork{},
+		&ClusterNetworkList{},
+		&TenantNetwork{},
+		&TenantNetworkList{},
 	)
 	meta_v1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -136,7 +136,7 @@ type TenantNetwork struct {
 type TenantNetworkList struct {
   meta_v1.TypeMeta `json:",inline"`
   meta_v1.ListMeta `json:"metadata"`
-  Items            []DanmNet `json:"items"`
+  Items            []TenantNetwork `json:"items"`
 }
 
 // VERY IMPORTANT NOT TO CHANGE THIS, INCLUDING THE EMPTY LINE BETWEEN THE ANNOTATIONS!!!
@@ -156,5 +156,5 @@ type ClusterNetwork struct {
 type ClusterNetworkList struct {
   meta_v1.TypeMeta `json:",inline"`
   meta_v1.ListMeta `json:"metadata"`
-  Items            []DanmNet `json:"items"`
+  Items            []ClusterNetwork `json:"items"`
 }

--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -48,16 +48,16 @@ type DanmNetOption struct {
   Vlan  int  `json:"vlan,omitempty"`
 }
 
-type IP4Pool struct {
-  Start string `json:"start"`
-  End   string `json:"end"`
-}
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type DanmNetList struct {
   meta_v1.TypeMeta `json:",inline"`
   meta_v1.ListMeta `json:"metadata"`
   Items            []DanmNet `json:"items"`
+}
+
+type IP4Pool struct {
+  Start string `json:"start"`
+  End   string `json:"end"`
 }
 
 // +genclient
@@ -95,6 +95,7 @@ type DanmEpList struct {
   meta_v1.ListMeta `json:"metadata"`
   Items            []DanmEp `json:"items"`
 }
+
 // VERY IMPORTANT NOT TO CHANGE THIS, INCLUDING THE EMPTY LINE BETWEEN THE ANNOTATIONS!!!
 // https://github.com/kubernetes/code-generator/issues/59
 // +genclient:nonNamespaced
@@ -121,4 +122,39 @@ type TenantConfigList struct {
   meta_v1.TypeMeta `json:",inline"`
   meta_v1.ListMeta `json:"metadata"`
   Items            []TenantConfig `json:"items"`
+}
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type TenantNetwork struct {
+  meta_v1.TypeMeta   `json:",inline"`
+  meta_v1.ObjectMeta `json:"metadata"`
+  Spec               DanmNetSpec `json:"spec"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type TenantNetworkList struct {
+  meta_v1.TypeMeta `json:",inline"`
+  meta_v1.ListMeta `json:"metadata"`
+  Items            []DanmNet `json:"items"`
+}
+
+// VERY IMPORTANT NOT TO CHANGE THIS, INCLUDING THE EMPTY LINE BETWEEN THE ANNOTATIONS!!!
+// https://github.com/kubernetes/code-generator/issues/59
+// +genclient:nonNamespaced
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +genclient
+type ClusterNetwork struct {
+  meta_v1.TypeMeta   `json:",inline"`
+  meta_v1.ObjectMeta `json:"metadata"`
+  Spec               DanmNetSpec `json:"spec"`
+}
+
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type ClusterNetworkList struct {
+  meta_v1.TypeMeta `json:",inline"`
+  meta_v1.ListMeta `json:"metadata"`
+  Items            []DanmNet `json:"items"`
 }

--- a/integration/crds/TenantNetwork.yaml
+++ b/integration/crds/TenantNetwork.yaml
@@ -41,6 +41,16 @@ spec:
                   type: string
                 device_pool:
                   type: string
+                vxlan:
+                  type: integer
+                  format: int32
+                  minimum: 1
+                  maximum: 16777214
+                vlan:
+                  type: integer
+                  format: int32
+                  minimum: 1
+                  maximum: 4094
                 rt_tables:
                   type: integer
                   format: int32

--- a/integration/manifests/netwatcher/0netwatcher_rbac.yaml
+++ b/integration/manifests/netwatcher/0netwatcher_rbac.yaml
@@ -17,6 +17,8 @@ rules:
   - "danm.k8s.io"
   resources:
   - danmnets
+  - clusternetworks
+  - tenantnetworks
   verbs:
   - get
   - list

--- a/pkg/admit/netadmit.go
+++ b/pkg/admit/netadmit.go
@@ -6,7 +6,6 @@ import (
   "net"
   "reflect"
   "strings"
-  "strconv"
   "time"
   "encoding/json"
   "math/rand"
@@ -217,33 +216,25 @@ func createPatchListFromNetChanges(origNetwork danmtypes.DanmNet, changedNetwork
   patchList := make([]Patch, 0)
   if origNetwork.Spec.Options.Alloc != changedNetwork.Spec.Options.Alloc {
     //TODO: Could (?) use some reflecting here to determine name of the struct field
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Alloc"],
-                json.RawMessage(`"` + changedNetwork.Spec.Options.Alloc + `"`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Alloc"], changedNetwork.Spec.Options.Alloc))
   }
   if origNetwork.Spec.NetworkType != changedNetwork.Spec.NetworkType {
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["NetworkType"],
-                json.RawMessage(`"` +  changedNetwork.Spec.NetworkType + `"`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["NetworkType"], changedNetwork.Spec.NetworkType))
   }
   if origNetwork.Spec.NetworkID != changedNetwork.Spec.NetworkID {
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["NetworkID"],
-                json.RawMessage(`"` +  changedNetwork.Spec.NetworkID + `"`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["NetworkID"], changedNetwork.Spec.NetworkID))
   }
   if !reflect.DeepEqual(origNetwork.Spec.Options.Pool, changedNetwork.Spec.Options.Pool) {
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Pool"],
-                json.RawMessage(`{"Start":"` + changedNetwork.Spec.Options.Pool.Start +
-                                `","End":"` + changedNetwork.Spec.Options.Pool.End + `"}`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Pool"], changedNetwork.Spec.Options.Pool))
   }
   if origNetwork.Spec.Options.Device != changedNetwork.Spec.Options.Device {
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Device"],
-                json.RawMessage(`"` + changedNetwork.Spec.Options.Device + `"`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Device"], changedNetwork.Spec.Options.Device))
   }
   if origNetwork.Spec.Options.Vlan != changedNetwork.Spec.Options.Vlan {
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Vlan"],
-                json.RawMessage(`"` + strconv.Itoa(changedNetwork.Spec.Options.Vlan) + `"`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Vlan"], changedNetwork.Spec.Options.Vlan))
   }
   if origNetwork.Spec.Options.Vxlan != changedNetwork.Spec.Options.Vxlan {
-    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Vxlan"],
-                json.RawMessage(`"` + strconv.Itoa(changedNetwork.Spec.Options.Vxlan) + `"`)))
+    patchList = append(patchList, CreateGenericPatchFromChange(NetworkPatchPaths["Vxlan"], changedNetwork.Spec.Options.Vxlan))
   }
   return patchList
 }

--- a/pkg/admit/utils.go
+++ b/pkg/admit/utils.go
@@ -18,7 +18,7 @@ import (
 type Patch struct {
   Op    string          `json:"op"`
   Path  string          `json:"path"`
-  Value json.RawMessage `json:"value"`
+  Value interface{}     `json:"value,omitempty"`
 }
 
 func DecodeAdmissionReview(httpRequest *http.Request) (*v1beta1.AdmissionReview,error) {
@@ -77,14 +77,14 @@ func CreateReviewResponseFromPatches(patchList []Patch) *v1beta1.AdmissionRespon
     }
   }
   if len(patches) > 0 {
-    reviewResponse.Patch = []byte(patches)
+    reviewResponse.Patch = patches
     pt := v1beta1.PatchTypeJSONPatch
     reviewResponse.PatchType = &pt
   }
   return &reviewResponse
 }
 
-func CreateGenericPatchFromChange(path string, value []byte ) Patch {
+func CreateGenericPatchFromChange(path string, value interface{} ) Patch {
   patch := Patch {
     Op:    "replace",
     Path:  path,

--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -1,79 +1,230 @@
 package netcontrol
 
 import (
+  "errors"
   "log"
-  "reflect"
+  "strconv"
   "strings"
   "time"
-  "k8s.io/client-go/rest"
-  "k8s.io/client-go/tools/cache"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   client "github.com/nokia/danm/crd/client/clientset/versioned/typed/danm/v1"
   danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
   danminformers "github.com/nokia/danm/crd/client/informers/externalversions"
   "github.com/nokia/danm/pkg/datastructs"
+  meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/client-go/rest"
+  "k8s.io/client-go/tools/cache"
 )
 
 // Handler represents an object watching the K8s API for changes in the DanmNet API path
 // Upon the reception of a notification it validates the body, and handles the related VxLAN/VLAN/RT creation/deletions on the host
 type NetWatcher struct {
-  Client danmclientset.Interface
-  Controllers []cache.Controller
+  Factories map[string]danminformers.SharedInformerFactory
+  Clients map[string]danmclientset.Interface
+  Controllers map[string]cache.Controller
 }
 
 // NewHandler initializes and returns a new Handler object
 // Upon the reception of a notification it performs DanmNet validation, and host network management operations
 // Handler contains additional members: one performing HTTPS operations, the other to interact with DamnEp objects
 func NewWatcher(cfg *rest.Config) (*NetWatcher,error) {
-  netWatcher := NetWatcher{}
-  client, err := danmclientset.NewForConfig(cfg)
-  if err != nil {
-    return &netWatcher, err
+  netWatcher := &NetWatcher{
+    Factories: make(map[string]danminformers.SharedInformerFactory),
+    Clients: make(map[string]danmclientset.Interface),
+    Controllers: make(map[string]cache.Controller),
   }
-  netWatcher.Client = client
-  danmInformerFactory := danminformers.NewSharedInformerFactory(client, time.Minute*10)
-  dnetController := danmInformerFactory.Danm().V1().DanmNets().Informer()
-  dnetController.AddEventHandler(cache.ResourceEventHandlerFuncs{
-      AddFunc: func(obj interface{}) {
-        AddDanmNet(netWatcher.Client, *(reflect.ValueOf(obj).Interface().(*danmtypes.DanmNet)))
-      },
-      DeleteFunc: func(obj interface{}) {
-        DeleteDanmNet(*(reflect.ValueOf(obj).Interface().(*danmtypes.DanmNet)))
-      },
-      UpdateFunc: func(oldObj, newObj interface{}) {
-     },
-  })
-  netWatcher.Controllers = append(netWatcher.Controllers, dnetController)
-  tnetController := danmInformerFactory.Danm().V1().TenantNetworks().Informer()
-  tnetController.AddEventHandler(cache.ResourceEventHandlerFuncs{
-      AddFunc: func(obj interface{}) {
-        AddDanmNet(netWatcher.Client, *(reflect.ValueOf(obj).Interface().(*danmtypes.DanmNet)))
-      },
-      DeleteFunc: func(obj interface{}) {
-        DeleteDanmNet(*(reflect.ValueOf(obj).Interface().(*danmtypes.DanmNet)))
-      },
-      UpdateFunc: func(oldObj, newObj interface{}) {
-     },
-  })
-  netWatcher.Controllers = append(netWatcher.Controllers, tnetController)
-  cnetController := danmInformerFactory.Danm().V1().ClusterNetworks().Informer()
-  cnetController.AddEventHandler(cache.ResourceEventHandlerFuncs{
-      AddFunc: func(obj interface{}) {
-        AddDanmNet(netWatcher.Client, *(reflect.ValueOf(obj).Interface().(*danmtypes.DanmNet)))
-      },
-      DeleteFunc: func(obj interface{}) {
-        DeleteDanmNet(*(reflect.ValueOf(obj).Interface().(*danmtypes.DanmNet)))
-      },
-      UpdateFunc: func(oldObj, newObj interface{}) {
-     },
-  })
-  netWatcher.Controllers = append(netWatcher.Controllers, cnetController)
-  return &netWatcher, nil
+  //this is how we test if the specific API is used within the cluster, or not
+  //we can only create an Informer for an existing API, otherwise we get errors
+  dnetClient, err := danmclientset.NewForConfig(cfg)
+  if err != nil {
+    return nil, err
+  } 
+  _, err = dnetClient.DanmV1().DanmNets("").List(meta_v1.ListOptions{})
+  if err == nil {
+    netWatcher.createDnetInformer(dnetClient)
+  }
+  tnetClient, err := danmclientset.NewForConfig(cfg)
+  if err != nil {
+    return nil, err
+  }
+  _, err = tnetClient.DanmV1().TenantNetworks("").List(meta_v1.ListOptions{})
+  if err == nil {
+    netWatcher.createTnetInformer(tnetClient)
+  }
+  cnetClient, err := danmclientset.NewForConfig(cfg)
+  if err != nil {
+    return nil, err
+  }
+  _, err = cnetClient.DanmV1().ClusterNetworks().List(meta_v1.ListOptions{})
+  if err == nil {
+    netWatcher.createCnetInformer(cnetClient)
+  }
+  log.Println("Number of watcher's started for recognized APIs:" + strconv.Itoa(len(netWatcher.Controllers)))
+  if len(netWatcher.Controllers) == 0 {
+    return nil, errors.New("no network management APIs are installed in the cluster, netwatcher cannot start!")
+  }
+  return netWatcher, nil
 }
 
 func (netWatcher *NetWatcher) Run(stopCh *chan struct{}) {
   for _, controller := range netWatcher.Controllers {
     go controller.Run(*stopCh)
+  }
+}
+
+
+func (netWatcher *NetWatcher) createDnetInformer(dnetClient danmclientset.Interface) { 
+  netWatcher.Clients["DanmNet"] = dnetClient
+  dnetInformerFactory := danminformers.NewSharedInformerFactory(dnetClient, time.Minute*10)
+  netWatcher.Factories["DanmNet"] = dnetInformerFactory
+  dnetController := dnetInformerFactory.Danm().V1().DanmNets().Informer()
+  dnetController.AddEventHandler(cache.ResourceEventHandlerFuncs{
+      AddFunc: AddDanmNet,
+      DeleteFunc: DeleteDanmNet,
+  })
+  netWatcher.Controllers["DanmNet"] = dnetController
+}
+
+func (netWatcher *NetWatcher) createTnetInformer(tnetClient danmclientset.Interface) {
+  netWatcher.Clients["TenantNetwork"] = tnetClient
+  tnetInformerFactory := danminformers.NewSharedInformerFactory(tnetClient, time.Minute*10)
+  netWatcher.Factories["TenantNetwork"] = tnetInformerFactory
+  tnetController := tnetInformerFactory.Danm().V1().TenantNetworks().Informer()
+  tnetController.AddEventHandler(cache.ResourceEventHandlerFuncs{
+      AddFunc: AddTenantNetwork,
+      DeleteFunc: DeleteTenantNetwork,
+  })
+  netWatcher.Controllers["TenantNetwork"] = tnetController
+}
+
+func (netWatcher *NetWatcher) createCnetInformer(cnetClient danmclientset.Interface) {
+  netWatcher.Clients["ClusterNetwork"] = cnetClient
+  cnetInformerFactory := danminformers.NewSharedInformerFactory(cnetClient, time.Minute*10)
+  netWatcher.Factories["ClusterNetwork"] = cnetInformerFactory
+  cnetController := cnetInformerFactory.Danm().V1().ClusterNetworks().Informer()
+  cnetController.AddEventHandler(cache.ResourceEventHandlerFuncs{
+      AddFunc: AddClusterNetwork,
+      DeleteFunc: DeleteClusterNetwork,
+  })
+  netWatcher.Controllers["ClusterNetwork"] = cnetController
+}
+
+func AddDanmNet(obj interface{}) {
+  dn, isNetwork := obj.(*danmtypes.DanmNet)
+  if !isNetwork {
+    log.Println("ERROR: Can't create interfaces for DanmNet, 'cause we have received an invalid object from the K8s API server")
+    return
+  }
+  err := setupHost(dn)
+  if err != nil {
+    log.Println("ERROR: Creating host interfaces for DanmNet:" + dn.ObjectMeta.Name + " failed with error:" + err.Error())
+  }
+}
+
+func DeleteDanmNet(obj interface{}) {
+  dn, isNetwork := obj.(*danmtypes.DanmNet)
+  if !isNetwork {
+    tombStone, objIsTombstone := obj.(cache.DeletedFinalStateUnknown)
+      if !objIsTombstone {
+        log.Println("ERROR: Can't delete interfaces for DanmNet, 'cause we have received an invalid object from the K8s API server")
+        return
+    }
+    var isObjectInTombStoneNetwork bool
+    dn, isObjectInTombStoneNetwork = tombStone.Obj.(*danmtypes.DanmNet)
+    if !isObjectInTombStoneNetwork {
+      log.Println("ERROR: Can't delete interfaces for DanmNet, 'cause we have received an invalid object from the K8s API server in the Event tombstone")
+      return
+    }
+  }
+  err := deleteNetworks(dn)
+  if err != nil {
+    log.Println("INFO: Deletion of host interfaces for DanmNet:" + dn.ObjectMeta.Name + " failed with error:" + err.Error())
+  }
+}
+
+func AddTenantNetwork(obj interface{}) {
+  tn, isNetwork := obj.(*danmtypes.TenantNetwork)
+  if !isNetwork {
+    log.Println("ERROR: Can't create interfaces for TenantNetwork, 'cause we have received an invalid object from the K8s API server")
+    return
+  }
+  dnet := ConvertTnetToDnet(tn)
+  err := setupHost(dnet)
+  if err != nil {
+    log.Println("ERROR: Creating host interfaces for TenantNetwork:" + dnet.ObjectMeta.Name + " failed with error:" + err.Error())
+  }
+}
+
+func DeleteTenantNetwork(obj interface{}) {
+  tn, isNetwork := obj.(*danmtypes.TenantNetwork)
+  if !isNetwork {
+    tombStone, objIsTombstone := obj.(cache.DeletedFinalStateUnknown)
+      if !objIsTombstone {
+        log.Println("ERROR: Can't delete interfaces for TenantNetwork, 'cause we have received an invalid object from the K8s API server")
+        return
+    }
+    var isObjectInTombStoneNetwork bool
+    tn, isObjectInTombStoneNetwork = tombStone.Obj.(*danmtypes.TenantNetwork)
+    if !isObjectInTombStoneNetwork {
+      log.Println("ERROR: Can't delete interfaces for TenantNetwork, 'cause we have received an invalid object from the K8s API server in the Event tombstone")
+      return
+    }
+  }
+  dn := ConvertTnetToDnet(tn)
+  err := deleteNetworks(dn)
+  if err != nil {
+    log.Println("INFO: Deletion of host interfaces for TenantNetwork:" + dn.ObjectMeta.Name + " failed with error:" + err.Error())
+  }
+}
+
+func AddClusterNetwork(obj interface{}) {
+  cn, isNetwork := obj.(*danmtypes.ClusterNetwork)
+  if !isNetwork {
+    log.Println("ERROR: Can't create interfaces for ClusterNetwork, 'cause we have received an invalid object from the K8s API server")
+    return
+  }
+  dnet := ConvertCnetToDnet(cn)
+  err := setupHost(dnet)
+  if err != nil {
+    log.Println("ERROR: Creating host interfaces for ClusterNetwork:" + dnet.ObjectMeta.Name + " failed with error:" + err.Error())
+  }
+}
+
+func DeleteClusterNetwork(obj interface{}) {
+  cn, isNetwork := obj.(*danmtypes.ClusterNetwork)
+  if !isNetwork {
+    tombStone, objIsTombstone := obj.(cache.DeletedFinalStateUnknown)
+      if !objIsTombstone {
+        log.Println("ERROR: Can't delete interfaces for ClusterNetwork, 'cause we have received an invalid object from the K8s API server")
+        return
+    }
+    var isObjectInTombStoneNetwork bool
+    cn, isObjectInTombStoneNetwork = tombStone.Obj.(*danmtypes.ClusterNetwork)
+    if !isObjectInTombStoneNetwork {
+      log.Println("ERROR: Can't delete interfaces for ClusterNetwork, 'cause we have received an invalid object from the K8s API server in the Event tombstone")
+      return
+    }
+  }
+  dn := ConvertCnetToDnet(cn)
+  err := deleteNetworks(dn)
+  if err != nil {
+    log.Println("INFO: Deletion of host interfaces for ClusterNetwork:" + dn.ObjectMeta.Name + " failed with error:" + err.Error())
+  }
+}
+
+func ConvertTnetToDnet(tnet *danmtypes.TenantNetwork) *danmtypes.DanmNet {
+  return &danmtypes.DanmNet {
+    TypeMeta: tnet.TypeMeta,
+    ObjectMeta: tnet.ObjectMeta,
+    Spec: tnet.Spec,
+  }
+}
+
+func ConvertCnetToDnet(cnet *danmtypes.ClusterNetwork) *danmtypes.DanmNet {
+  return &danmtypes.DanmNet {
+    TypeMeta: cnet.TypeMeta,
+    ObjectMeta: cnet.ObjectMeta,
+    Spec: cnet.Spec,
   }
 }
 
@@ -88,24 +239,4 @@ func PutDanmNet(client client.DanmNetInterface, dnet *danmtypes.DanmNet) (bool,e
     return wasResourceAlreadyUpdated, err
   }
   return wasResourceAlreadyUpdated, nil
-}
-
-// validate DanmNet body
-// update validity in apiserver, don't care for 409 (PATCH or PUT)
-// create host specific network stuff: rt_tables, vlan, and vxlan interfaces
-func AddDanmNet(client danmclientset.Interface, dn danmtypes.DanmNet) {
-  err := setupHost(&dn)
-  if err != nil {
-    log.Println("ERROR: Creating host interfaces for DanmNet:" + dn.ObjectMeta.Name + " failed with error:" + err.Error())
-  }
-  return
-}
-
-// delete host_specific network stuff: rt_tables, vlan, and vxlan interfaces
-func DeleteDanmNet(dn danmtypes.DanmNet) {
-  err := deleteNetworks(&dn)
-  if err != nil {
-    log.Println("INFO: Deletion of host interfaces for DanmNet:" + dn.ObjectMeta.Name + " failed with error:" + err.Error())
-  }
-  return
 }

--- a/schema/TenantConfig.yaml
+++ b/schema/TenantConfig.yaml
@@ -15,29 +15,28 @@ metadata:
   # Name of the K8s TenantNetwork object this file represents
   # MANDATORY - STRING
   name: ## TENANTCONFIG_NAME  ##
-spec:
-  # A list of physical network interfaces in the cluster's Node's host network namespace tenant users can connect to.
-  # Whenever a TenantNetwork is created with a NetworkType requiring direct access to a host device (e.g. ipvlan, macvlan etc.), DANM automatically selects one from this list.
-  # The selected interface is then configured in the TenantNetwork object's "host_device" attribute.
-  # MANDATORY - LIST OF INTERFACE PROFILES USABLE BY TENANTS
-  hostDevices:
-    # One host device profile can have the following attributes:
-    #   The name of the network device as seen in the Linux kernel. E.g. eno4, bond1 etc.
-    #   MANDATORY - STRING
-    # - name: ## DEVICE_NAME ##
-    #   The cluster administrator can configure if TenantNetworks should be connected to a virtual network rather than directly to the physical device.
-    #   VLANs and VxLANs are supported, but they are mutually exclusive within the same profile.
-    #   OPTIONAL STRING PARAMETER, ONE OF {vlan, vxlan}
-    #   vniType: ## TYPE_OF_VIRTUAL_NETWORK ##
-    #   The VNI range assigned to the tenants can be configured in this attribute, if container interfaces aren't directly connected to the physical device.
-    #   VLAN/VxLAN respective VNI kernel limits apply.
-    #   When a virtual network is configured for an interface, DANM automatically selects a free VNI from the provided range, and configures into the TenantNetworks respective field (spec.Options.vlan, or spec.Options.vxlan).
-    #   MANDATORY WHEN "vniType" IS DEFINED, STRING TYPE LIST NOTATION WITH RANGES E.G. "2000-2500,2601,2650-2700"
-    #   vniRange ## VNI_RANGE ##
-  # Cluster administrators can configure which CNI config files should be used by a tenant when they ask network connections to statically configured backends (i.e. not IPVLAN, MACVLAN, or SR-IOV).
-  # The name of the CNI config files used for static network provisioning operations are chosen via the TenantNetwork's NetworkID parameter.
-  # If the tenant user configures a static backend into the spec.NetworkType attribute of the TenantNetwork object, the NetworkID parameter will be overwritten with the value configured into this attribute.
-  # OPTIONAL - MAP OF NETWORTYPE:NETWORKID ENTRIES (e.g. "flannel: tenant1_config")
-  networkIds:
-    ## NETWORKTYPE1: NETWORKID1 ##
-    ## NETWORKTYPE2: NETWORKID2 ##
+# A list of physical network interfaces in the cluster's Node's host network namespace tenant users can connect to.
+# Whenever a TenantNetwork is created with a NetworkType requiring direct access to a host device (e.g. ipvlan, macvlan etc.), DANM automatically selects one from this list.
+# The selected interface is then configured in the TenantNetwork object's "host_device" attribute.
+# MANDATORY - LIST OF INTERFACE PROFILES USABLE BY TENANTS
+hostDevices:
+  # One host device profile can have the following attributes:
+  #   The name of the network device as seen in the Linux kernel. E.g. eno4, bond1 etc.
+  #   MANDATORY - STRING
+  # - name: ## DEVICE_NAME ##
+  #   The cluster administrator can configure if TenantNetworks should be connected to a virtual network rather than directly to the physical device.
+  #   VLANs and VxLANs are supported, but they are mutually exclusive within the same profile.
+  #   OPTIONAL STRING PARAMETER, ONE OF {vlan, vxlan}
+  #   vniType: ## TYPE_OF_VIRTUAL_NETWORK ##
+  #   The VNI range assigned to the tenants can be configured in this attribute, if container interfaces aren't directly connected to the physical device.
+  #   VLAN/VxLAN respective VNI kernel limits apply.
+  #   When a virtual network is configured for an interface, DANM automatically selects a free VNI from the provided range, and configures into the TenantNetworks respective field (spec.Options.vlan, or spec.Options.vxlan).
+  #   MANDATORY WHEN "vniType" IS DEFINED, STRING TYPE LIST NOTATION WITH RANGES E.G. "2000-2500,2601,2650-2700"
+  #   vniRange ## VNI_RANGE ##
+# Cluster administrators can configure which CNI config files should be used by a tenant when they ask network connections to statically configured backends (i.e. not IPVLAN, MACVLAN, or SR-IOV).
+# The name of the CNI config files used for static network provisioning operations are chosen via the TenantNetwork's NetworkID parameter.
+# If the tenant user configures a static backend into the spec.NetworkType attribute of the TenantNetwork object, the NetworkID parameter will be overwritten with the value configured into this attribute.
+# OPTIONAL - MAP OF NETWORTYPE:NETWORKID ENTRIES (e.g. "flannel: tenant1_config")
+networkIds:
+  ## NETWORKTYPE1: NETWORKID1 ##
+  ## NETWORKTYPE2: NETWORKID2 ##

--- a/test/stubs/client_stub.go
+++ b/test/stubs/client_stub.go
@@ -24,6 +24,14 @@ func (client *ClientStub) TenantConfigs() client.TenantConfigInterface {
   return nil
 }
 
+func (client *ClientStub) TenantNetworks(namespace string) client.TenantNetworkInterface {
+  return nil
+}
+
+func (client *ClientStub) ClusterNetworks() client.ClusterNetworkInterface {
+  return nil
+}
+
 func (c *ClientStub) RESTClient() rest.Interface {
   return nil
 }


### PR DESCRIPTION
Binary is reworked to be able to hold, and run more than one Controllers/Informers.
NetWatcher will hold 3 of them from now on: DanmNet, TenantNetwork, and ClusterNetwork.
It does not matter which API is getting modified, NetWatcher will handle them the exact same way.

