### PR TITLE
DANM 4.0 EP6: Adapting CNI code to work with all the APIs

### DIFF
--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -77,6 +77,7 @@ type DanmEpSpec struct {
   Pod         string      `json:"Pod"`
   CID         string      `json:"CID,omitempty"`
   Netns       string      `json:"netns,omitempty"`
+  ApiType     string      `json:"apiType"`
 }
 
 type DanmEpIface struct {

--- a/integration/cni_config/danm_rbac.yaml
+++ b/integration/cni_config/danm_rbac.yaml
@@ -9,6 +9,8 @@ rules:
     resources:
     - danmnets
     - danmeps
+    - tenantnetworks
+    - clusternetworks
     verbs: [ "*" ]
   - apiGroups: [ "" ]
     resources: [ "pods" ]

--- a/pkg/admit/netdel.go
+++ b/pkg/admit/netdel.go
@@ -7,9 +7,9 @@ import (
   "github.com/nokia/danm/pkg/confman"
 )
 
-//A GIGANTIC DISCLAIMER: THIS DOES NOT WORK UNTIL K8S 1.15 IS RELEASED!
+//A GIGANTIC DISCLAIMER: THIS DOES NOT WORK BEFORE K8S 1.15!
 //See ticket: https://github.com/kubernetes/kubernetes/pull/76346
-//Until then, don't use in production!
+//Tested with 1.15 though, works like a charm
 func DeleteNetwork(responseWriter http.ResponseWriter, request *http.Request) {
   admissionReview, err := DecodeAdmissionReview(request)
   if err != nil {

--- a/pkg/datastructs/datastructs.go
+++ b/pkg/datastructs/datastructs.go
@@ -10,9 +10,9 @@ const (
 
 type NetConf struct {
   types.NetConf
-  Kubeconfig   string `json:"kubeconfig"`
-  CniConfigDir string `json:"cniDir"`
-  NamingScheme string `json:"namingScheme"`
+  Kubeconfig          string `json:"kubeconfig"`
+  CniConfigDir        string `json:"cniDir"`
+  NamingScheme        string `json:"namingScheme"`
 }
 
 type CniBackend struct {
@@ -20,17 +20,19 @@ type CniBackend struct {
 }
 
 // Interface represents a request coming from the Pod to connect it to one DanmNet during CNI_ADD operation
-// It contains the name of the DanmNet the Pod should be connected to, and other optional requests
+// It contains the name of the network object the Pod should be connected to, and other optional requests
 // Pods can influence the scheme of IP allocation (dynamic, static, none),
 // and can ask for the provisioning of policy-based IP routes
 type Interface struct {
-  Network string `json:"network"`
-  Ip string `json:"ip"`
-  Ip6 string `json:"ip6"`
-  Proutes map[string]string `json:"proutes"`
-  Proutes6 map[string]string `json:"proutes6"`
+  Network        string `json:"network,omitempty"`
+  TenantNetwork  string `json:"tenantNetwork,omitempty"`
+  ClusterNetwork string `json:"clusterNetwork,omitempty"`
+  Ip  string `json:"ip,omitempty"`
+  Ip6 string `json:"ip6,omitempty"`
+  Proutes  map[string]string `json:"proutes,omitempty"`
+  Proutes6 map[string]string `json:"proutes6,omitempty"`
   DefaultIfaceName string
-  Device string `json:"Device,omitempty"`
+  Device string
   SequenceId int
 }
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -16,10 +16,10 @@ import (
   "github.com/nokia/danm/pkg/bitarray"
 )
 
-// Reserve inspects the DanmNet object received as an input, and allocates an IPv4 or IPv6 address from the appropriate allocation pool
+// Reserve inspects the network object received as an input, and allocates an IPv4 or IPv6 address from the appropriate allocation pool
 // In case static IP allocation is requested, it will try reserver the requested error. If it is not possible, it returns an error
 // The reserved IP address is represented by setting a bit in the network's BitArray type allocation matrix
-// The refreshed DanmNet object is modified in the K8s API server at the end
+// The refreshed network object is modified in the K8s API server at the end
 func Reserve(danmClient danmclientset.Interface, netInfo danmtypes.DanmNet, req4, req6 string) (string, string, string, error) {
   tempNetSpec := netInfo
   for {
@@ -39,9 +39,9 @@ func Reserve(danmClient danmclientset.Interface, netInfo danmtypes.DanmNet, req4
   }
 }
 
-// Free inspects the DanmNet object received as an input, and releases an IPv4 or IPv6 address from the appropriate allocation pool
+// Free inspects the network object received as an input, and releases an IPv4 or IPv6 address from the appropriate allocation pool
 // The IP address liberation is represented by unsetting a bit in the network's BitArray type allocation matrix
-// The refreshed DanmNet object is modified in the K8s API server at the end
+// The refreshed network object is modified in the K8s API server at the end
 func Free(danmClient danmclientset.Interface, netInfo danmtypes.DanmNet, ip string) error {
   if netInfo.Spec.Options.Alloc == "" || ip == "" {
     // Nothing to return here: either network, or the interface is an L2

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -527,7 +527,7 @@ func DeleteInterfaces(args *skel.CmdArgs) error {
 }
 
 func deleteInterface(danmClient danmclientset.Interface, args *cniArgs, syncher *syncher.Syncher, ep danmtypes.DanmEp) {
-  netInfo, err := danmClient.DanmV1().DanmNets(args.nameSpace).Get(ep.Spec.NetworkName, meta_v1.GetOptions{})
+  netInfo, err := netcontrol.GetNetworkFromEp(danmClient, ep)
   if err != nil {
     syncher.PushResult(ep.Spec.NetworkName, errors.New("failed to get DanmNet:"+ err.Error()), nil)
     return

--- a/schema/TenantConfig.yaml
+++ b/schema/TenantConfig.yaml
@@ -32,7 +32,7 @@ hostDevices:
   #   VLAN/VxLAN respective VNI kernel limits apply.
   #   When a virtual network is configured for an interface, DANM automatically selects a free VNI from the provided range, and configures into the TenantNetworks respective field (spec.Options.vlan, or spec.Options.vxlan).
   #   MANDATORY WHEN "vniType" IS DEFINED, STRING TYPE LIST NOTATION WITH RANGES E.G. "2000-2500,2601,2650-2700"
-  #   vniRange ## VNI_RANGE ##
+  #   vniRange: ## VNI_RANGE ##
 # Cluster administrators can configure which CNI config files should be used by a tenant when they ask network connections to statically configured backends (i.e. not IPVLAN, MACVLAN, or SR-IOV).
 # The name of the CNI config files used for static network provisioning operations are chosen via the TenantNetwork's NetworkID parameter.
 # If the tenant user configures a static backend into the spec.NetworkType attribute of the TenantNetwork object, the NetworkID parameter will be overwritten with the value configured into this attribute.

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -58,9 +58,6 @@ var testNets = []danmtypes.DanmNet {
     ObjectMeta: meta_v1.ObjectMeta {Name: "hululululu"},
     Spec: danmtypes.DanmNetSpec{NetworkID: "hululululu", NetworkType: "hululululu"},
   },
-  danmtypes.DanmNet{
-    Spec: danmtypes.DanmNetSpec{NetworkID: "nometa", NetworkType: "macvlan"},
-  },
   danmtypes.DanmNet {
     ObjectMeta: meta_v1.ObjectMeta {Name: "ipamNeeded"},
     Spec: danmtypes.DanmNetSpec{NetworkType: "macvlan", NetworkID: "cidr",},
@@ -153,17 +150,14 @@ var testEps = []danmtypes.DanmEp {
 
 var delegationRequiredTcs = []struct {
   netName string
-  isErrorExpected bool
   isDelegationExpected bool
 }{
-  {"empty", false, false},
-  {"ipvlan", false, false},
-  {"IPVLAN-UPPER", false, false},
-  {"sriov", false, true},
-  {"flannel", false, true},
-  {"hululululu", false, true},
-  {"error", true, false},
-  {"nometa", true, false},
+  {"empty", false},
+  {"ipvlan", false},
+  {"IPVLAN-UPPER", false},
+  {"sriov", true},
+  {"flannel", true},
+  {"hululululu", true},
 }
 
 var isDeviceNeededTcs = []struct {
@@ -212,17 +206,10 @@ var delDeleteTcs = []struct {
 }
 
 func TestIsDelegationRequired(t *testing.T) {
-  netClientStub := stubs.NewClientSetStub(testNets, nil, nil)
   for _, tc := range delegationRequiredTcs {
     t.Run(tc.netName, func(t *testing.T) {
-      isDelRequired,_,err := cnidel.IsDelegationRequired(netClientStub,tc.netName,"hululululu")
-      if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
-        var detailedErrorMessage string
-        if err != nil {
-          detailedErrorMessage = err.Error()
-        }
-        t.Errorf("Received error does not match with expectation: %t for TC: %s, detailed error message: %s", tc.isErrorExpected, tc.netName, detailedErrorMessage)
-      }
+      dnet := getTestNet(tc.netName)
+      isDelRequired := cnidel.IsDelegationRequired(dnet)
       if isDelRequired != tc.isDelegationExpected {
         t.Errorf("Received delegation result does not match with expected for TC: %s", tc.netName)
       }


### PR DESCRIPTION
This requires basically changing the code which deals with the external interfaces -both uplink and downlink-, but does not require us to re-write everything.
We only need to convert everything to DanmNet type, then the internals continue to work as-is.

Refactoring happened where it was absolutely required, for example in the handling of the annotation, and the default networks.
The code generally only got better.