### PR TITLE
DANM 4.0 EP7: Adapting Svcwatcher code to independently recognize the three network management APIs

### DIFF
--- a/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
+++ b/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
@@ -36,7 +36,6 @@ rules:
 - apiGroups:
   - "danm.k8s.io"
   resources:
-  - danmnets
   - danmeps
   verbs:
   - get

--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -266,8 +266,8 @@ func PutNetwork(danmClient danmclientset.Interface, dnet *danmtypes.DanmNet) (bo
     cn := ConvertDnetToCnet(dnet)
     _, err = danmClient.DanmV1().ClusterNetworks().Update(cn)
   } else {
-    return wasResourceAlreadyUpdated, errors.New("can't refresh network object because it has an invalid type:" + dnet.TypeMeta.Kind)  
-  }  
+    return wasResourceAlreadyUpdated, errors.New("can't refresh network object because it has an invalid type:" + dnet.TypeMeta.Kind)
+  }
   if err != nil {
     if strings.Contains(err.Error(),datastructs.OptimisticLockErrorMsg) {
       wasResourceAlreadyUpdated = true

--- a/schema/DanmService.yaml
+++ b/schema/DanmService.yaml
@@ -18,11 +18,21 @@ metadata:
     # DANM uses the information for the same purpose as teh default Service controller - for every Pod matching all key-value pairs in the selector field, one Endpoint will be created.
     # MANDATORY - JSON FORMATTED LIST OF STRING:STRING ASSOCIATIONS (e.g. '{"app":"loadbalancer"},{"type":"sctp"}')
     danm.k8s.io/selector: ## POD_SELECTORS ##
-    # When DANM creates an Endpoint for a selected Pod, it will populate it with the selected interface's IP.
-    # The selected interface will be the one which is connected to the DanmNet object identified (i.e. matching ObjectMeta.Name) in this attribute.
+    # When DANM creates an Endpoint for a selected Pod, it populates it with the selected interface's IP.
+    # If you want a Service to select an interface connected to a DanmNet, set the name of the DanmNet object into this attribute.
     # Pods, DanmNets, and Services are all namespaced resources, so an Endpoint is created only if all three are within the same K8s namespace.
-    # MANDATORY - STRING
+    # OPTIONAL {AT LEAST ONE OF "network", "tenantNetwork", AND "clusterNetwork" shall be defined } - STRING
     danm.k8s.io/network: ## NETWORK_SELECTOR ##
+    # When DANM creates an Endpoint for a selected Pod, it populates it with the selected interface's IP.
+    # If you want a Service to select an interface connected to a TenantNetwork, set the name of the TenantNetwork object into this attribute.
+    # Pods, TenantNetworks, and Services are all namespaced resources, so an Endpoint is created only if all three are within the same K8s namespace.
+    # OPTIONAL {AT LEAST ONE OF "network", "tenantNetwork", AND "clusterNetwork" shall be defined } - STRING
+    danm.k8s.io/tenantNetwork: ## NETWORK_SELECTOR ##
+    # When DANM creates an Endpoint for a selected Pod, it populates it with the selected interface's IP.
+    # If you want a Service to select an interface connected to a ClusterNetwork, set the name of the ClusterNetwork object into this attribute.
+    # As ClusterNetworks are not namespaced resources, EndPoints are created whenever a Pod connects to a matching ClusterNetwork in the same namespace as this Service.
+    # OPTIONAL {AT LEAST ONE OF "network", "tenantNetwork", AND "clusterNetwork" shall be defined } - STRING
+    danm.k8s.io/clusterNetwork: ## NETWORK_SELECTOR ##
 spec:
   # DANM recognized Services are selectorless Services, because we want to avoid default Kubernetes controllers to create an Endpoint to a wrong network interface.
   # Selectorless Services don't have a spec.selector present in their object.


### PR DESCRIPTION
We do this by adding two new network selectors into the DANM compatible Service API schema.
Each network API has its own, explicit selector, independent from each other.

Thus it becomes possible for users to explicitly control which management API they want their EndPoints to select. This functionality is needed, because the different APIs can contains networks with the exact same name, even within the exact same namespace (e.g. if someone would use DanmNet and TenantNetwork together, for some reason)