### PR TITLE
Some interfaces are not properly cleaned during CNI_ADD if some other interface creations fail

### DIFF
--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -63,13 +63,13 @@ func DelegateInterfaceSetup(netConf *datastructs.NetConf, danmClient danmclients
   }
   rawConfig, err := getCniPluginConfig(netConf, netInfo, ipamOptions, ep)
   if err != nil {
-    freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     return nil, err
   }
   cniType := netInfo.Spec.NetworkType
   cniResult,err := execCniPlugin(cniType, CniAddOp, netInfo, rawConfig, ep)
   if err != nil {
-    freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     return nil, errors.New("Error delegating ADD to CNI plugin:" + cniType + " because:" + err.Error())
   }
   if cniResult != nil {
@@ -187,19 +187,19 @@ func setEpIfaceAddress(cniResult *current.Result, epIface *danmtypes.DanmEpIface
 func DelegateInterfaceDelete(netConf *datastructs.NetConf, danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ep *danmtypes.DanmEp) error {
   rawConfig, err := getCniPluginConfig(netConf, netInfo, datastructs.IpamConfig{Type: ipamType}, ep)
   if err != nil {
-    freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     return err
   }
   cniType := netInfo.Spec.NetworkType
   _, err = execCniPlugin(cniType, CniDelOp, netInfo, rawConfig, ep)
   if err != nil {
-    freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     return errors.New("Error delegating DEL to CNI plugin:" + cniType + " because:" + err.Error())
   }
-  return freeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+  return FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
 }
 
-func freeDelegatedIps(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ip4, ip6 string) error {
+func FreeDelegatedIps(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ip4, ip6 string) error {
   err4 := freeDelegatedIp(danmClient, netInfo, ip4)
   err6 := freeDelegatedIp(danmClient, netInfo, ip6)
   if err4 != nil {

--- a/pkg/syncher/syncher.go
+++ b/pkg/syncher/syncher.go
@@ -28,13 +28,13 @@ func NewSyncher(numOfResults int) *Syncher {
 }
 
 func (synch *Syncher) PushResult(cniName string, opRes error, cniRes *current.Result) {
+  synch.mux.Lock()
+  defer synch.mux.Unlock()
   cniOpResult := cniOpResult {
     CniName: cniName,
     OpResult: opRes,
     CniResult: cniRes,
   }
-  synch.mux.Lock()
-  defer synch.mux.Unlock()
   synch.CniResults = append(synch.CniResults, cniOpResult)
 }
 


### PR DESCRIPTION
Finally caught a very nasty race-condition / edge use-case present since 3.2.

The root cause is that in some cases we have returned earlier during interface creation, than starting the asynch thread.
But if some other threads have already progressed to the point of forking, they were basically prematurely reaped by the early termination of the whole process, and/or by the subsequent and almost immediately triggered CNI_DEL.
Really nasty :)

Resolution is getting rid of ALL early return cases once we have progressed to interface creation. In case of an early failure we simply push the result in to the syncher object, even if the error happened in the main thread.
Only Syncher can return from the main thread, no sooner and no later than all results are available: be them pushed from the main thread, or from a fork.
