### PR TITLE
UTs for newly introduced confman package

### DIFF
--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -28,6 +28,7 @@ func main() {
   validator, err := admit.CreateNewValidator()
   if err != nil {
     log.Println("ERROR: Cannot create DANM REST client, because:" + err.Error())
+    return
   }
   http.HandleFunc("/netvalidation", validator.ValidateNetwork)
   http.HandleFunc("/confvalidation", validator.ValidateTenantConfig)

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -25,9 +25,13 @@ func main() {
     log.Println("ERROR: TLS configuration could not be initialized, because:" + err.Error())
     return
   }
-  http.HandleFunc("/netvalidation", admit.ValidateNetwork)
-  http.HandleFunc("/confvalidation", admit.ValidateTenantConfig)
-  http.HandleFunc("/netdeletion", admit.DeleteNetwork)
+  validator, err := admit.CreateNewValidator()
+  if err != nil {
+    log.Println("ERROR: Cannot create DANM REST client, because:" + err.Error())
+  }
+  http.HandleFunc("/netvalidation", validator.ValidateNetwork)
+  http.HandleFunc("/confvalidation", validator.ValidateTenantConfig)
+  http.HandleFunc("/netdeletion", validator.DeleteNetwork)
   server := &http.Server{
     Addr:         *address + ":" + strconv.Itoa(*port),
     TLSConfig:    &tls.Config{Certificates: []tls.Certificate{tlsConf}},

--- a/pkg/admit/confadmit.go
+++ b/pkg/admit/confadmit.go
@@ -17,7 +17,7 @@ const (
   HostDevicePath = "/hostDevices"
 )
 
-func ValidateTenantConfig(responseWriter http.ResponseWriter, request *http.Request) {
+func (validator *Validator) ValidateTenantConfig(responseWriter http.ResponseWriter, request *http.Request) {
   admissionReview, err := DecodeAdmissionReview(request)
   if err != nil {
     SendErroneousAdmissionResponse(responseWriter, admissionReview.Request.UID, err)

--- a/pkg/admit/netdel.go
+++ b/pkg/admit/netdel.go
@@ -10,7 +10,7 @@ import (
 //A GIGANTIC DISCLAIMER: THIS DOES NOT WORK BEFORE K8S 1.15!
 //See ticket: https://github.com/kubernetes/kubernetes/pull/76346
 //Tested with 1.15 though, works like a charm
-func DeleteNetwork(responseWriter http.ResponseWriter, request *http.Request) {
+func (validator *Validator) DeleteNetwork(responseWriter http.ResponseWriter, request *http.Request) {
   admissionReview, err := DecodeAdmissionReview(request)
   if err != nil {
     SendErroneousAdmissionResponse(responseWriter, admissionReview.Request.UID, err)
@@ -22,7 +22,7 @@ func DeleteNetwork(responseWriter http.ResponseWriter, request *http.Request) {
     return
   }
   if oldManifest.TypeMeta.Kind == "TenantNetwork" && IsTypeDynamic(oldManifest.Spec.NetworkType) {
-    tconf, err := confman.GetTenantConfig()
+    tconf, err := confman.GetTenantConfig(validator.Client)
     if err != nil {
       SendErroneousAdmissionResponse(responseWriter, admissionReview.Request.UID,
       errors.New("The network's VNI could not be freed, because:" + err.Error()))

--- a/pkg/admit/netdel.go
+++ b/pkg/admit/netdel.go
@@ -28,7 +28,7 @@ func (validator *Validator) DeleteNetwork(responseWriter http.ResponseWriter, re
       errors.New("The network's VNI could not be freed, because:" + err.Error()))
       return
     }
-    err = confman.Free(tconf,oldManifest)
+    err = confman.Free(validator.Client, tconf, oldManifest)
     if err != nil {
       SendErroneousAdmissionResponse(responseWriter, admissionReview.Request.UID,
       errors.New("The network's VNI could not be freed, because:" + err.Error()))

--- a/pkg/admit/validators.go
+++ b/pkg/admit/validators.go
@@ -16,9 +16,9 @@ const (
 )
 
 var (
-  DanmNetMapping = []Validator{validateIpv4Fields,validateIpv6Fields,validateAllocationPool,validateVids,validateNetworkId,validateAbsenceOfAllowedTenants,validateNeType}
-  ClusterNetMapping = []Validator{validateIpv4Fields,validateIpv6Fields,validateAllocationPool,validateVids,validateNeType,validateNetworkId}
-  TenantNetMapping = []Validator{validateIpv4Fields,validateIpv6Fields,validateAllocationPool,validateAbsenceOfAllowedTenants,validateTenantNetRules,validateNeType}
+  DanmNetMapping = []ValidatorFunc{validateIpv4Fields,validateIpv6Fields,validateAllocationPool,validateVids,validateNetworkId,validateAbsenceOfAllowedTenants,validateNeType}
+  ClusterNetMapping = []ValidatorFunc{validateIpv4Fields,validateIpv6Fields,validateAllocationPool,validateVids,validateNeType,validateNetworkId}
+  TenantNetMapping = []ValidatorFunc{validateIpv4Fields,validateIpv6Fields,validateAllocationPool,validateAbsenceOfAllowedTenants,validateTenantNetRules,validateNeType}
   danmValidationConfig = map[string]ValidatorMapping {
     "DanmNet": DanmNetMapping,
     "ClusterNetwork": ClusterNetMapping,
@@ -26,8 +26,8 @@ var (
   }
 )
 
-type Validator func(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error
-type ValidatorMapping []Validator
+type ValidatorFunc func(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error
+type ValidatorMapping []ValidatorFunc
 
 func validateIpv4Fields(oldManifest, newManifest *danmtypes.DanmNet, opType admissionv1.Operation) error {
   return validateIpFields(newManifest.Spec.Options.Cidr, newManifest.Spec.Options.Routes)

--- a/pkg/confman/confman.go
+++ b/pkg/confman/confman.go
@@ -4,27 +4,23 @@ import (
   "errors"
   "log"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
   "github.com/nokia/danm/pkg/bitarray"
   "github.com/nokia/danm/pkg/metacni"
   metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
   "k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
-func GetTenantConfig() (*danmtypes.TenantConfig, error) {
-  danmClient, err := metacni.CreateDanmClient("")
-  if err != nil {
-    return nil, err
-  }
+func GetTenantConfig(danmClient danmclientset.Interface) (*danmtypes.TenantConfig, error) {
   reply, err := danmClient.DanmV1().TenantConfigs().List(metav1.ListOptions{})
   if err != nil {
     return nil, err
   }
-  configs := reply.Items
-  if len(configs) == 0 {
+  if reply == nil || len(reply.Items) == 0 {
     return nil, errors.New("TenantNetworks cannot be created without provisioning a TenantConfig first!")
   }
   //TODO: do a namespace based selection later if one generic config does not suffice
-  return &configs[0], nil
+  return &reply.Items[0], nil
 }
 
 func Reserve(tconf *danmtypes.TenantConfig, iface danmtypes.IfaceProfile) (int,error) {

--- a/schema/TenantConfig.yaml
+++ b/schema/TenantConfig.yaml
@@ -16,12 +16,15 @@ metadata:
   # MANDATORY - STRING
   name: ## TENANTCONFIG_NAME  ##
 # A list of physical network interfaces in the cluster's Node's host network namespace tenant users can connect to.
-# Whenever a TenantNetwork is created with a NetworkType requiring direct access to a host device (e.g. ipvlan, macvlan etc.), DANM automatically selects one from this list.
-# The selected interface is then configured in the TenantNetwork object's "host_device" attribute.
+# Whenever a TenantNetwork is created with a NetworkType requiring direct access to a host device (i.e. ipvlan, macvlan), or to a K8s Device pool (i.e. sriov),
+# DANM selects an appropriate one from this list.
+# The physical details from the selected interface are then configured to the relevant attributes in the TenantNetwork (host_device/device_pool, vlan, vxlan).
 # MANDATORY - LIST OF INTERFACE PROFILES USABLE BY TENANTS
 hostDevices:
   # One host device profile can have the following attributes:
-  #   The name of the network device as seen in the Linux kernel. E.g. eno4, bond1 etc.
+  #   The name of the physical device used by the network. It can be either:
+  #   - the name of a network device as seen in the Linux kernel for NetworkTypes directly connecting to a PF E.g. eno4, bond1 etc.
+  #   - the name of a Kubernetes managed Device Pool, in case the NetworkType is Device dependent (such as sriov)
   #   MANDATORY - STRING
   # - name: ## DEVICE_NAME ##
   #   The cluster administrator can configure if TenantNetworks should be connected to a virtual network rather than directly to the physical device.

--- a/test/stubs/client_stub.go
+++ b/test/stubs/client_stub.go
@@ -6,22 +6,37 @@ import (
   rest "k8s.io/client-go/rest"
 )
 
+type TestArtifacts struct {
+  TestNets []danmtypes.DanmNet
+  TestEps []danmtypes.DanmEp
+  ReservedIps []ReservedIpsList
+  TestTconfs []danmtypes.TenantConfig
+}
+
+type ReservedIpsList struct {
+  NetworkId string
+  Reservations []Reservation
+}
+
+type Reservation struct {
+  Ip string
+  Set bool
+}
+
 type ClientStub struct {
-  testNets []danmtypes.DanmNet
-  testEps []danmtypes.DanmEp
-  reservedIps []ReservedIpsList
+  Objects TestArtifacts
 }
 
 func (client *ClientStub) DanmNets(namespace string) client.DanmNetInterface {
-  return newNetClientStub(client.testNets, client.reservedIps)
+  return newNetClientStub(client.Objects.TestNets, client.Objects.ReservedIps)
 }
 
 func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {
-  return newEpClientStub(client.testEps)
+  return newEpClientStub(client.Objects.TestEps)
 }
 
 func (client *ClientStub) TenantConfigs() client.TenantConfigInterface {
-  return nil
+  return newTconfClientStub(client.Objects.TestTconfs)
 }
 
 func (client *ClientStub) TenantNetworks(namespace string) client.TenantNetworkInterface {
@@ -36,10 +51,8 @@ func (c *ClientStub) RESTClient() rest.Interface {
   return nil
 }
 
-func newClientStub(nets []danmtypes.DanmNet, eps []danmtypes.DanmEp, ips []ReservedIpsList) *ClientStub {
+func newClientStub(ta TestArtifacts) *ClientStub {
   return &ClientStub {
-    testNets: nets,
-    testEps: eps,
-    reservedIps: ips,
+    Objects: ta,
   }
 }

--- a/test/stubs/clientset_stub.go
+++ b/test/stubs/clientset_stub.go
@@ -3,21 +3,10 @@ package stubs
 import (
   discovery "k8s.io/client-go/discovery"
   danmv1 "github.com/nokia/danm/crd/client/clientset/versioned/typed/danm/v1"
-  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
 )
 
 type ClientSetStub struct {
   danmClient *ClientStub
-}
-
-type ReservedIpsList struct {
-  NetworkId string
-  Reservations []Reservation
-}
-
-type Reservation struct {
-  Ip string
-  Set bool
 }
 
 func (c *ClientSetStub) DanmV1() danmv1.DanmV1Interface {
@@ -32,8 +21,8 @@ func (c *ClientSetStub) Discovery() discovery.DiscoveryInterface {
   return nil
 }
 
-func NewClientSetStub(nets []danmtypes.DanmNet, eps []danmtypes.DanmEp, ips []ReservedIpsList) *ClientSetStub {
+func NewClientSetStub(objects TestArtifacts) *ClientSetStub {
   var clientSet ClientSetStub
-  clientSet.danmClient = newClientStub(nets, eps, ips)
+  clientSet.danmClient = newClientStub(objects)
   return &clientSet
 }

--- a/test/stubs/tconfclient_stub.go
+++ b/test/stubs/tconfclient_stub.go
@@ -1,0 +1,64 @@
+package stubs
+
+import (
+  "errors"
+  "strings"
+  meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  types "k8s.io/apimachinery/pkg/types"
+  watch "k8s.io/apimachinery/pkg/watch"
+)
+  
+type TconfClientStub struct{
+  testTconfs []danmtypes.TenantConfig
+}
+
+func newTconfClientStub(tconfs []danmtypes.TenantConfig) TconfClientStub {
+  return TconfClientStub{testTconfs: tconfs}
+}
+  
+func (tconfClient TconfClientStub) Create(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
+  return nil, nil
+}
+
+func (tconfClient TconfClientStub) Update(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
+  return nil, nil
+}
+
+func (tconfClient TconfClientStub) Delete(name string, options *meta_v1.DeleteOptions) error {
+  return nil
+}
+
+func (tconfClient TconfClientStub) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+  return nil
+}
+
+func (tconfClient TconfClientStub) Get(tconfNameName string, options meta_v1.GetOptions) (*danmtypes.TenantConfig, error) {
+  for _, tconf := range tconfClient.testTconfs {
+    if tconf.ObjectMeta.Name == tconfNameName {
+      return &tconf, nil
+    }
+  }
+  return nil, nil
+}
+
+func (tconfClient TconfClientStub) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+  watch := watch.NewEmptyWatch()
+  return watch, nil
+}
+
+func (tconfClient TconfClientStub) List(opts meta_v1.ListOptions) (*danmtypes.TenantConfigList, error) {
+  if tconfClient.testTconfs == nil {
+    return nil, nil
+  }
+  if strings.HasPrefix(tconfClient.testTconfs[0].ObjectMeta.Name,"error") {
+    return nil, errors.New("error happened")
+  }
+  tconfList := danmtypes.TenantConfigList{Items: tconfClient.testTconfs }
+  return &tconfList, nil
+}
+
+func (tconfClient TconfClientStub) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *danmtypes.TenantConfig, err error) {
+  return nil, nil
+}
+

--- a/test/stubs/tconfclient_stub.go
+++ b/test/stubs/tconfclient_stub.go
@@ -22,7 +22,10 @@ func (tconfClient TconfClientStub) Create(obj *danmtypes.TenantConfig) (*danmtyp
 }
 
 func (tconfClient TconfClientStub) Update(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
-  return nil, nil
+  if strings.HasPrefix(obj.ObjectMeta.Name,"error") {
+    return nil, errors.New("here you go")
+  }
+  return &danmtypes.TenantConfig{}, nil
 }
 
 func (tconfClient TconfClientStub) Delete(name string, options *meta_v1.DeleteOptions) error {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -35,6 +35,15 @@ func SetupAllocationPools(nets []danmtypes.DanmNet) error {
   return nil
 }
 
+func GetTestNet(netId string, testNets []danmtypes.DanmNet) *danmtypes.DanmNet {
+  for _, net := range testNets {
+    if net.ObjectMeta.Name == netId {
+      return &net
+    }
+  }
+  return nil
+}
+
 func exhaustNetwork(netInfo *danmtypes.DanmNet) {
     ba := bitarray.NewBitArrayFromBase64(netInfo.Spec.Options.Alloc)
     _, ipnet, _ := net.ParseCIDR(netInfo.Spec.Options.Cidr)

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -208,7 +208,7 @@ var delDeleteTcs = []struct {
 func TestIsDelegationRequired(t *testing.T) {
   for _, tc := range delegationRequiredTcs {
     t.Run(tc.netName, func(t *testing.T) {
-      dnet := getTestNet(tc.netName)
+      dnet := utils.GetTestNet(tc.netName, testNets)
       isDelRequired := cnidel.IsDelegationRequired(dnet)
       if isDelRequired != tc.isDelegationExpected {
         t.Errorf("Received delegation result does not match with expected for TC: %s", tc.netName)
@@ -280,7 +280,7 @@ func TestDelegateInterfaceSetup(t *testing.T) {
       if err != nil {
         t.Errorf("TC could not be set-up because:%s", err.Error())
       }
-      testNet := getTestNet(tc.netName)
+      testNet := utils.GetTestNet(tc.netName, testNets)
       testEp := getTestEp(tc.epName)
       cniRes, err := cnidel.DelegateInterfaceSetup(&cniConf,netClientStub,testNet,testEp)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
@@ -327,7 +327,7 @@ func TestDelegateInterfaceDelete(t *testing.T) {
       if err != nil {
         t.Errorf("TC could not be set-up because:%s", err.Error())
       }
-      testNet := getTestNet(tc.netName)
+      testNet := utils.GetTestNet(tc.netName, testNets)
       testEp := getTestEp(tc.epName)
       if testNet.Spec.NetworkType == "flannel" && testEp.Spec.Iface.Address != "" {
         var dataDir = filepath.Join(defaultDataDir, flannelBridge)
@@ -424,15 +424,6 @@ func setupDelTestTc(expectedCniConfig string) error {
   err := ioutil.WriteFile(filepath.Join(cniTestConfigDir, cniTestConfigFile), expectedConf.Conftent, 0666)
   if err != nil {
     return err
-  }
-  return nil
-}
-
-func getTestNet(netId string) *danmtypes.DanmNet {
-  for _, net := range testNets {
-    if net.ObjectMeta.Name == netId {
-      return &net
-    }
   }
   return nil
 }

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -268,7 +268,8 @@ func TestCalculateIfaceName(t *testing.T) {
 }
 
 func TestDelegateInterfaceSetup(t *testing.T) {
-  netClientStub := stubs.NewClientSetStub(testNets, nil, nil)
+  testArtifacts := stubs.TestArtifacts{TestNets: testNets}
+  netClientStub := stubs.NewClientSetStub(testArtifacts)
   err := setupDelTest("ADD")
   if err != nil {
     t.Errorf("Test suite could not be set-up because:%s", err.Error())
@@ -314,7 +315,8 @@ func TestDelegateInterfaceSetup(t *testing.T) {
 }
 
 func TestDelegateInterfaceDelete(t *testing.T) {
-  netClientStub := stubs.NewClientSetStub(testNets, nil, nil)
+  testArtifacts := stubs.TestArtifacts{TestNets: testNets}
+  netClientStub := stubs.NewClientSetStub(testArtifacts)
   err := setupDelTest("DEL")
   if err != nil {
     t.Errorf("Test suite could not be set-up because:%s", err.Error())

--- a/test/uts/confman_test/confman_test.go
+++ b/test/uts/confman_test/confman_test.go
@@ -3,6 +3,7 @@ package confman_test
 import (
   "testing"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/bitarray"
   "github.com/nokia/danm/pkg/confman"
   "github.com/nokia/danm/test/stubs"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,17 @@ type TconfSet struct {
   tconfs []danmtypes.TenantConfig
 }
 
+const (
+  AllocFor5k = "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+)
+
 var (
   emptyTconfs []danmtypes.TenantConfig
   errorTconfs = []danmtypes.TenantConfig {
@@ -25,6 +37,27 @@ var (
   multipleTconfs = []danmtypes.TenantConfig {
     danmtypes.TenantConfig{ObjectMeta: meta_v1.ObjectMeta {Name: "firstConf"}},
     danmtypes.TenantConfig{ObjectMeta: meta_v1.ObjectMeta {Name: "secondConf"}},
+  }
+  reserveConfs = []danmtypes.TenantConfig {
+    danmtypes.TenantConfig{
+      ObjectMeta: meta_v1.ObjectMeta {Name: "tconf"},
+      HostDevices: []danmtypes.IfaceProfile {
+        danmtypes.IfaceProfile{Name: "ens4", VniType: "vxlan", VniRange: "700-710", Alloc:AllocFor5k},
+        danmtypes.IfaceProfile{Name: "ens4", VniType: "vlan", VniRange: "200,500-510", Alloc:AllocFor5k},
+      },
+    },
+    danmtypes.TenantConfig{
+      ObjectMeta: meta_v1.ObjectMeta {Name: "error"},
+      HostDevices: []danmtypes.IfaceProfile {
+        danmtypes.IfaceProfile{Name: "ens4", VniType: "vxlan", VniRange: "800-810", Alloc:AllocFor5k},
+      },
+    },
+  }
+  reserveIfaces = []danmtypes.IfaceProfile {
+    danmtypes.IfaceProfile{Name:"invalidVni", VniRange: "invalid"},
+    danmtypes.IfaceProfile{Name: "ens4", VniType: "vxlan", VniRange: "700-710", Alloc:AllocFor5k},
+    danmtypes.IfaceProfile{Name: "ens4", VniType: "vlan", VniRange: "200,500-510", Alloc:AllocFor5k},
+    danmtypes.IfaceProfile{Name: "hupak", VniType: "vlan", VniRange: "1000,1001", Alloc:AllocFor5k},
   }
   tconfSets = []TconfSet {
     TconfSet{name: "emptyTcs", tconfs: emptyTconfs},
@@ -42,6 +75,23 @@ var getTconfTcs = []struct {
   {"emptyTcs", testConfigs, true},
   {"errorTconfs", testConfigs, true},
   {"multipleConfigs", testConfigs, false},
+}
+
+var reserveTcs = []struct {
+  tcName string
+  tconfName string
+  ifaceName string
+  vniType string
+  reserveVnis []int
+  isErrorExpected bool
+  expectedVni int
+}{
+  {"invalidVni", "tconf", "invalidVni", "", nil, true, 0},
+  {"reserveFirstFreeInEmptyIface", "tconf", "ens4", "vlan", nil, false, 200},
+  {"reserveLastFreeInIface", "tconf", "ens4", "vlan", []int{200,509}, false, 510},
+  {"noFreeVniInIface", "tconf", "ens4", "vlan", []int{200,510}, true, 0},
+  {"errorUpdating", "error", "ens4", "vxlan", nil, true, 0},
+  {"nonExistentProfile", "tconf", "hupak", "vlan", nil, true, 0},
 }
 
 func TestGetTenantConfig(t *testing.T) {
@@ -62,6 +112,36 @@ func TestGetTenantConfig(t *testing.T) {
   }
 }
 
+func TestReserve(t *testing.T) {
+  for _, tc := range reserveTcs {
+    t.Run(tc.tcName, func(t *testing.T) {
+      tconf := getTconf(tc.tconfName, reserveConfs)
+      iface := getIface(tc.ifaceName, tc.vniType, reserveIfaces)
+      if tc.reserveVnis != nil {
+        reserveVnis(&iface,tc.reserveVnis)
+      }
+      testArtifacts := stubs.TestArtifacts{TestTconfs: reserveConfs}
+      tconfClientStub := stubs.NewClientSetStub(testArtifacts)
+      vni, err := confman.Reserve(tconfClientStub, tconf, iface)
+      if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
+        t.Errorf("Received error:%v does not match with expectation", err)
+        return
+      }
+      if tc.expectedVni != 0 {
+        if tc.expectedVni != vni {
+          t.Errorf("Received reserved VNI:%d does not match with expected:%d",vni,tc.expectedVni)
+          return
+        }
+        _, updatedIface := getIfaceFromTconf(tc.ifaceName, tc.vniType, tconf)
+        if updatedIface.Alloc == iface.Alloc {
+          t.Errorf("Alloc field in the selected inteface profile did not change even though a VNI was reserved!")
+          return
+        }
+      }
+    })
+  }
+}
+
 func getTconfSet(tconfName string, tconfSets []TconfSet) []danmtypes.TenantConfig {
   for _, tconfSet := range tconfSets {
     if tconfSet.name == tconfName {
@@ -69,4 +149,39 @@ func getTconfSet(tconfName string, tconfSets []TconfSet) []danmtypes.TenantConfi
     }
   }
   return nil
+}
+
+func getTconf(tconfName string, tconfSet []danmtypes.TenantConfig) *danmtypes.TenantConfig {
+  for _, tconf := range tconfSet {
+    if tconf.ObjectMeta.Name == tconfName {
+      return &tconf
+    }
+  }
+  return nil
+}
+
+func getIface(ifaceName string, vniType string, ifaceSet []danmtypes.IfaceProfile) danmtypes.IfaceProfile {
+  for _, iface := range ifaceSet {
+    if iface.Name == ifaceName && iface.VniType == vniType{
+      return iface
+    }
+  }
+  return danmtypes.IfaceProfile{}
+}
+
+func getIfaceFromTconf(ifaceName string, vniType string, tconf *danmtypes.TenantConfig) (int,danmtypes.IfaceProfile) {
+  for index, iface := range tconf.HostDevices {
+    if iface.Name == ifaceName && iface.VniType == vniType {
+      return index, iface
+    }
+  }
+  return -1, danmtypes.IfaceProfile{}
+}
+
+func reserveVnis(iface *danmtypes.IfaceProfile, vniRange []int) {
+  allocs := bitarray.NewBitArrayFromBase64(iface.Alloc)
+  for i := vniRange[0]; i <= vniRange[1]; i++ {
+    allocs.Set(uint32(i))
+  }
+  iface.Alloc = allocs.Encode()
 }

--- a/test/uts/confman_test/confman_test.go
+++ b/test/uts/confman_test/confman_test.go
@@ -1,0 +1,72 @@
+package confman_test
+
+import (
+  "testing"
+  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/confman"
+  "github.com/nokia/danm/test/stubs"
+  meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type TconfSets struct {
+  sets []TconfSet
+}
+
+type TconfSet struct {
+  name string
+  tconfs []danmtypes.TenantConfig
+}
+
+var (
+  emptyTconfs []danmtypes.TenantConfig
+  errorTconfs = []danmtypes.TenantConfig {
+    danmtypes.TenantConfig{ObjectMeta: meta_v1.ObjectMeta {Name: "error"}},
+  }
+  multipleTconfs = []danmtypes.TenantConfig {
+    danmtypes.TenantConfig{ObjectMeta: meta_v1.ObjectMeta {Name: "firstConf"}},
+    danmtypes.TenantConfig{ObjectMeta: meta_v1.ObjectMeta {Name: "secondConf"}},
+  }
+  tconfSets = []TconfSet {
+    TconfSet{name: "emptyTcs", tconfs: emptyTconfs},
+    TconfSet{name: "errorTconfs", tconfs: errorTconfs},
+    TconfSet{name: "multipleConfigs", tconfs: multipleTconfs},
+  }
+  testConfigs = TconfSets {sets: tconfSets}
+)
+
+var getTconfTcs = []struct {
+  tcName string
+  tconfSets TconfSets
+  isErrorExpected bool
+}{
+  {"emptyTcs", testConfigs, true},
+  {"errorTconfs", testConfigs, true},
+  {"multipleConfigs", testConfigs, false},
+}
+
+func TestGetTenantConfig(t *testing.T) {
+  for _, tc := range getTconfTcs {
+    t.Run(tc.tcName, func(t *testing.T) {
+      tconfSet := getTconfSet(tc.tcName, tc.tconfSets.sets)
+      testArtifacts := stubs.TestArtifacts{TestTconfs: tconfSet}
+      tconfClientStub := stubs.NewClientSetStub(testArtifacts)
+      tconf, err := confman.GetTenantConfig(tconfClientStub)
+      if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
+        t.Errorf("Received error:%v does not match with expectation", err)
+        return
+      }
+      if tconf != nil && tconf.ObjectMeta.Name != tconfSet[0].ObjectMeta.Name {
+        t.Errorf("The name of the returned TenantConfig:%s does not match with the expected:%s", tconf.ObjectMeta.Name, tconfSet[0].ObjectMeta.Name)
+      }
+    })
+  }
+}
+
+func getTconfSet(tconfName string, tconfSets []TconfSet) []danmtypes.TenantConfig {
+  for _, tconfSet := range tconfSets {
+    if tconfSet.name == tconfName {
+      return tconfSet.tconfs
+    }
+  }
+  return nil
+}

--- a/test/uts/confman_test/confman_test.go
+++ b/test/uts/confman_test/confman_test.go
@@ -99,6 +99,10 @@ var (
       ObjectMeta: meta_v1.ObjectMeta {Name: "sriov_vxlan"},
       Spec: danmtypes.DanmNetSpec{NetworkID: "ext", NetworkType: "sriov", Options: danmtypes.DanmNetOption{DevicePool: "nokia.k8s.io/sriov_ens1f0", Vxlan: 1600}},
     },
+    danmtypes.DanmNet {
+      ObjectMeta: meta_v1.ObjectMeta {Name: "novni"},
+      Spec: danmtypes.DanmNetSpec{NetworkID: "internal", NetworkType: "ipvlan", Options: danmtypes.DanmNetOption{Device: "ens4"}},
+    },
   }
 )
 
@@ -144,7 +148,8 @@ var freeTcs = []struct {
   {"hostDeviceWithVxlan", "tconf", "ipvlan_vxlan", "ens4", "vxlan", false, false},
   {"devicePoolWithVlan", "tconf", "sriov_vlan", "nokia.k8s.io/sriov_ens1f0", "vlan", false, false},
   {"devicePoolWithVxlan", "tconf", "sriov_vxlan", "nokia.k8s.io/sriov_ens1f0", "vxlan", false, false},
-  {"errorUpdating", "error", "ipvlan_vxlan", "ens4", "vxlan", false, true},  
+  {"errorUpdating", "error", "ipvlan_vxlan", "ens4", "vxlan", false, true},
+  {"noVnis", "tconf", "novni", "", "", false, false},
 }
 
 func TestGetTenantConfig(t *testing.T) {

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -102,7 +102,8 @@ func TestReserve(t *testing.T) {
   for _, tc := range reserveTcs {
     t.Run(tc.netName, func(t *testing.T) {
       ips := createExpectedAllocationsList(tc.expectedIp4,true,tc.netIndex)
-      netClientStub := stubs.NewClientSetStub(testNets, nil, ips)
+      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      netClientStub := stubs.NewClientSetStub(testArtifacts)
       ip4, ip6, mac, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         t.Errorf("Received error:%v does not match with expectation", err)
@@ -131,7 +132,8 @@ func TestFree(t *testing.T) {
   for _, tc := range freeTcs {
     t.Run(tc.netName, func(t *testing.T) {
       ips := createExpectedAllocationsList(tc.allocatedIp,false,tc.netIndex)
-      netClientStub := stubs.NewClientSetStub(testNets, nil, ips)
+      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      netClientStub := stubs.NewClientSetStub(testArtifacts)
       err := ipam.Free(netClientStub, testNets[tc.netIndex], tc.allocatedIp)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         t.Errorf("Received error:%v does not match with expectation", err)
@@ -149,7 +151,8 @@ func TestGarbageCollectIps(t *testing.T) {
   for _, tc := range gcTcs {
     t.Run(tc.netName, func(t *testing.T) {
       ips := createExpectedAllocationsList(tc.allocatedIp4,false,tc.netIndex)
-      netClientStub := stubs.NewClientSetStub(testNets, nil, ips)
+      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      netClientStub := stubs.NewClientSetStub(testArtifacts)
       ipam.GarbageCollectIps(netClientStub, &testNets[tc.netIndex], tc.allocatedIp4, tc.allocatedIp6)
     })
   }


### PR DESCRIPTION
Started adding UTs for new 4.0 confman package.
Refactoring is -again- needed to be able to test the new changes:
- for easy future extension stub instantiation now takes one struct called TestArtifacts
- webhook function are refactored to use a pre-created DANM client as a member of a struct, rather than everyone using their own
The original approach was unstubbable, the new -hopefully- won't run into race conditions