### PR TITLE
Link to the Akraino REC architecture and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ That being said, tell us about your Kubernetes breaking ideas! We are open to ac
 Just because something doesn't fit into DANM, it does not mean it can't fit into your cloud! 
 ## Getting started
 ### Install an Akraino REC and get DANM for free!
-Just kidding as DANM is always free, but if you want to install a production grade, open-source Kubernetes-based bare metal CaaS infrastructure by default equipped with DANM **and** with a single click of a button nonetheless; just head over to Linux Foundation Akraino Radio Edge Cloud (REC) wiki for the [Akraino REC Architecture](https://wiki.akraino.org/display/AK/REC+Architecture+Document) and the [Akraino REC Intallation Guide](https://wiki.akraino.org/display/AK/REC+Installation+Guide)
+Just kidding as DANM is always free, but if you want to install a production grade, open-source Kubernetes-based bare metal CaaS infrastructure by default equipped with DANM **and** with a single click of a button nonetheless; just head over to Linux Foundation Akraino Radio Edge Cloud (REC) wiki for the [Akraino REC Architecture](https://wiki.akraino.org/display/AK/REC+Architecture+Document) and the [Akraino REC Installation Guide](https://wiki.akraino.org/display/AK/REC+Installation+Guide)
 Not just for TelCo!
 ### Prerequisites
 Otherwise, you need to create your own Kubernetes cluster, and install DANM manually. We suggest to use any of the automated Kubernetes installing solutions (kubeadm, minikube etc.) for a painless experience.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ That being said, tell us about your Kubernetes breaking ideas! We are open to ac
 Just because something doesn't fit into DANM, it does not mean it can't fit into your cloud! 
 ## Getting started
 ### Install an Akraino REC and get DANM for free!
-Just kidding as DANM is always free, but if you want to install a production grade, open-source Kubernetes-based bare metal CaaS infrastructure by default equipped with DANM **and** with a single click of a button nonetheless; just head over to Linux Foundation Akraino Radio Edge Cloud site:
-[Akraino REC Wiki](https://wiki.akraino.org/display/AK/Telco+Appliance+Blueprint+Family)
+Just kidding as DANM is always free, but if you want to install a production grade, open-source Kubernetes-based bare metal CaaS infrastructure by default equipped with DANM **and** with a single click of a button nonetheless; just head over to Linux Foundation Akraino Radio Edge Cloud (REC) wiki for the [Akraino REC Architecture](https://wiki.akraino.org/display/AK/REC+Architecture+Document) and the [Akraino REC Intallation Guide](https://wiki.akraino.org/display/AK/REC+Installation+Guide)
 Not just for TelCo!
 ### Prerequisites
 Otherwise, you need to create your own Kubernetes cluster, and install DANM manually. We suggest to use any of the automated Kubernetes installing solutions (kubeadm, minikube etc.) for a painless experience.


### PR DESCRIPTION
Changing the link of the Akraino REC blueprint family to a link ot the Akraino REC architecture ans the intall guide.

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> bug
> cleanup
> design
documentation
> failing-test
> feature

**What does this PR give to us**:
Better links to Akraino REC

**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None