### PR TITLE
DANM centralized, API driven API management extended to work for all CNI compliant backends

### DIFF
--- a/cmd/cnitest/cnitest.go
+++ b/cmd/cnitest/cnitest.go
@@ -123,17 +123,17 @@ func validateMacvlanConfig(receivedCniConfig, expectedCniConfig []byte, tcConf T
   var recMacvlanConf cnidel.MacvlanNet
   err := json.Unmarshal(receivedCniConfig, &recMacvlanConf)
   if err != nil {
-    return errors.New("Received MACVLAN config could not be unmarshalled, because:" + err.Error())
+    return errors.New("Received CNI config could not be unmarshalled, because:" + err.Error())
   }
-  log.Printf("Received MACVLAN config:%v",recMacvlanConf)
+  log.Printf("Received CNI config:%v",recMacvlanConf)
   var expMacvlanConf MacvlanCniTestConfig
   err = json.Unmarshal(expectedCniConfig, &expMacvlanConf)
   if err != nil {
-    return errors.New("Expected MACVLAN config could not be unmarshalled, because:" + err.Error())
+    return errors.New("Expected CNI config could not be unmarshalled, because:" + err.Error())
   }
   if tcConf.CniExpectations.Ip6 != "" {
     if recMacvlanConf.Ipam.Ips == nil {
-      return errors.New("Received MACVLAN CNI config does not contain IPv6 address under ipam section, but it shall!")
+      return errors.New("Received CNI config does not contain IPv6 address under ipam section, but it shall!")
     }
     newIpamConfig := datastructs.IpamConfig{Type: "fakeipam"}
     for _,ip := range recMacvlanConf.Ipam.Ips {
@@ -142,11 +142,11 @@ func validateMacvlanConfig(receivedCniConfig, expectedCniConfig []byte, tcConf T
       }
     }
     recMacvlanConf.Ipam = newIpamConfig
-    log.Printf("Received MACVLAN config after IPv6 adjustment:%v",recMacvlanConf)
+    log.Printf("Received config after IPv6 adjustment:%v",recMacvlanConf)
   }
-  log.Printf("Expected MACVLAN config:%v",expMacvlanConf.CniConf)
+  log.Printf("Expected config:%v",expMacvlanConf.CniConf)
   if !reflect.DeepEqual(recMacvlanConf, expMacvlanConf.CniConf) {
-    return errors.New("Received MACVLAN delegate configuration does not match with expected!")
+    return errors.New("Received delegate configuration does not match with expected!")
   }
   return nil
 }

--- a/schema/ClusterNetwork.yaml
+++ b/schema/ClusterNetwork.yaml
@@ -14,16 +14,16 @@ metadata:
 spec:
   # This parameter provides a second identifier for ClusterNetworks, and can be used to control a number of API features.
   # For static delegates, the parameter configures which CNI configuration file is to be used if NetworkType points to a static-level CNI backend.
-  # For dynamic delegates, VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
+  # VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
   # This allows deployment administrators to separate their own interfaces from others' in a multi-tenant environment, i.e. by setting NetworkID to "name_namespace" value.
-  # OPTIONAL - STRING, MAXIMUM 12 CHARACTERS
+  # OPTIONAL - STRING, MAXIMUM 11 CHARACTERS
   NetworkID: ## NETWORK_ID  ##
   # This parameter, denotes which backend is used to provision the container interface connected to this network.
   # Currently supported values with dynamic integration level are IPVLAN (default), SRIOV, or MACVLAN.
   # - IPVLAN option results in an IPVLAN sub-interface provisioned in L2 mode, and connected to the designated host device
   # - SRIOV option pushes a pre-allocated Virtual Function of the configured host device to the container's netns
   # - MACVLAN option results in a MACVLAN sub-interface provisioned in bridge mode, and connected to the designated host device
-  # Setting this option to another value results in delegating the network provisioning operation to the named backend with static configuration (i.e. most Options are ignored).
+  # Setting this option to another value results in delegating the network provisioning operation to the named backend with static configuration (i.e. coming from a standard CNI config file).
   # The default IPVLAN backend is used when this parameter is not specified.
   # OPTIONAL - ONE OF {ipvlan,sriov,macvlan,<NAME_OF_ANY_STATIC_LEVEL_CNI_COMPLIANT_BINARY>}
   # DEFAULT VALUE: ipvlan
@@ -37,9 +37,8 @@ spec:
   # - K8S_NAMESPACE1
   # - K8S_NAMESPACE2
   # Specific extra configuration options can be passed to the network provisioning backends.
-  # Most of the parameters are only supported for dynamic level backends, such as IPVLAN, MACVLAN, and SRIOV.
-  # Other network interfaces are always provisioned based on their associated static CNI configuration files.
-  # The exceptional attributes are "rt_tables", "container_prefix", and "routes/6". DANM universally supports the features related to these parameters for all CNI backends.
+  # Most of the parameters are generally supported for all network types.
+  # Options only supported for dynamic level backends, such as IPVLAN, MACVLAN, and SRIOV are explicitly noted.
   Options:
     # Name of the parent host device (i.e. physical host NIC).
     # Sub-interfaces are connected to this NIC in case NetworkType is set to IPVLAN, or MACVLAN.
@@ -53,13 +52,11 @@ spec:
     # OPTIONAL - STRING
     device_pool: ## DEVICE_PLUGIN_RESOURCE_POOL_MAME ##
     # The IPv4 CIDR notation of the subnet associated with the network.
-    # Pods connecting to this network will get their IPv4 IP from this subnet, if defined.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
+    # Pods connecting to this network get an IPv4 address to their interface from this subnet.
     # OPTIONAL - IPv4 CIDR FORMAT (e.g. "10.0.0.0/24")
     cidr: ## SUBNET_CIDR ##
     # IPv4 allocation will be done according to the narrowed down allocation pool parameter, if defined.
     # Allocation pool must be provided together with "cidr", and shall be included in the subnet range.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
     # If CIDR is provided without defining an allocation pool, it is automatically calculated for the whole netmask (minus the first, and the last IP).
     # The gateway IPs of all the configured IP routes are also automatically reserved from the allocation pool when it is generated.
     # When the network administrator sets the allocation pool, DANM assumes the non-usable IPs (e.g. broadcast IP, gateway IPs etc.) were already discounted.
@@ -67,10 +64,8 @@ spec:
       start: ## FIRST_ASSIGNABLE_IP ##
       end: ## LAST_ASSIGNABLE_IP ##
     # The IPv6 CIDR notation of the subnet associated with the network.
-    # Pods connecting to this network will get their IPv6 addresses from this subnet, if defined.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
-    # OPTIONAL - IPv6 CIDR FORMAT (e.g. "2001:db8::/45").
-    # NOTE: Netmask of the subnet cannot be higher than /64 (i.e. /65 and upwards).
+    # Pods connecting to this network will get their IPv6s from this subnet, if defined.
+    # OPTIONAL - IPv6 CIDR FORMAT (e.g. "2001:db8::/45"). Netmask of the subnet cannot be higher than /64 (i.e. /65 and upwards).
     net6: ## SUBNET_CIDR ##
     # Interfaces connected to this network are renamed inside the Pod's network namespace to a string starting with "container_prefix".
     # If not provided, DANM uses "eth" as the prefix.

--- a/schema/DanmNet.yaml
+++ b/schema/DanmNet.yaml
@@ -13,29 +13,28 @@ metadata:
 spec:
   # This parameter provides a second identifier for DanmNets, and can be used to control a number of API features.
   # For static delegates, the parameter configures which CNI configuration file is to be used if NetworkType points to a static-level CNI backend.
-  # For dynamic delegates, VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
+  # VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
   # This allows deployment administrators to separate their own interfaces from others' in a multi-tenant environment, i.e. by setting NetworkID to "name_namespace" value.
-  # OPTIONAL - STRING, MAXIMUM 12 CHARACTERS
+  # OPTIONAL - STRING, MAXIMUM 11 CHARACTERS
   NetworkID: ## NETWORK_ID  ##
   # This parameter, denotes which backend is used to provision the container interface connected to this network.
   # Currently supported values with dynamic integration level are IPVLAN (default), SRIOV, or MACVLAN.
   # - IPVLAN option results in an IPVLAN sub-interface provisioned in L2 mode, and connected to the designated host device
   # - SRIOV option pushes a pre-allocated Virtual Function of the configured host device to the container's netns
   # - MACVLAN option results in a MACVLAN sub-interface provisioned in bridge mode, and connected to the designated host device
-  # Setting this option to another value results in delegating the network provisioning operation to the named backend with static configuration (i.e. most Options are ignored).
+  # Setting this option to another value results in delegating the network provisioning operation to the named backend with static configuration (i.e. coming from a standard CNI config file).
   # The default IPVLAN backend is used when this parameter is not specified.
   # OPTIONAL - ONE OF {ipvlan,sriov,macvlan,<NAME_OF_ANY_STATIC_LEVEL_CNI_COMPLIANT_BINARY>}
   # DEFAULT VALUE: ipvlan
   NetworkType: ## BACKEND_TYPE ##
   # Specific extra configuration options can be passed to the network provisioning backends.
-  # Most of the parameters are only supported for dynamic level backends, such as IPVLAN, MACVLAN, and SRIOV.
-  # Other network interfaces are always provisioned based on their associated static CNI configuration files.
-  # The exceptional attributes are "rt_tables", "container_prefix", and "routes/6". DANM universally supports the features related to these parameters for all CNI backends.
+  # Most of the parameters are generally supported for all network types.
+  # Options only supported for dynamic level backends, such as IPVLAN, MACVLAN, and SRIOV are explicitly noted.
   Options:
     # Name of the parent host device (i.e. physical host NIC).
     # Sub-interfaces are connected to this NIC in case NetworkType is set to IPVLAN, or MACVLAN.
     # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
-    # Also ignored for SR-IOV, as the pre-allocated Virtual Functions belonging to the configured Kubernetes Device pool are pushed into the connecting Pod's network namespace, regardless which Physical Funtion they belong to.
+    # Also ignored for SR-IOV, as the pre-allocated Virtual Functions belonging to a configured Kubernetes Device pool are pushed into the connecting Pod's network namespace, regardless which Physical Funtion they belong to.
     # OPTIONAL - STRING
     host_device: ## PARENT_DEVICE_NAME ##
     # Name of a network Device Plugin resource pool
@@ -44,13 +43,11 @@ spec:
     # OPTIONAL - STRING
     device_pool: ## DEVICE_PLUGIN_RESOURCE_POOL_MAME ##
     # The IPv4 CIDR notation of the subnet associated with the network.
-    # Pods connecting to this network will get their IPv4 IP from this subnet, if defined.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
+    # Pods connecting to this network get an IPv4 address to their interface from this subnet.
     # OPTIONAL - IPv4 CIDR FORMAT (e.g. "10.0.0.0/24")
     cidr: ## SUBNET_CIDR ##
     # IPv4 allocation will be done according to the narrowed down allocation pool parameter, if defined.
     # Allocation pool must be provided together with "cidr", and shall be included in the subnet range.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
     # If CIDR is provided without defining an allocation pool, it is automatically calculated for the whole netmask (minus the first, and the last IP).
     # The gateway IPs of all the configured IP routes are also automatically reserved from the allocation pool when it is generated.
     # When the network administrator sets the allocation pool, DANM assumes the non-usable IPs (e.g. broadcast IP, gateway IPs etc.) were already discounted.
@@ -59,7 +56,6 @@ spec:
       end: ## LAST_ASSIGNABLE_IP ##
     # The IPv6 CIDR notation of the subnet associated with the network.
     # Pods connecting to this network will get their IPv6s from this subnet, if defined.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
     # OPTIONAL - IPv6 CIDR FORMAT (e.g. "2001:db8::/45"). Netmask of the subnet cannot be higher than /64 (i.e. /65 and upwards).
     net6: ## SUBNET_CIDR ##
     # Interfaces connected to this network are renamed inside the Pod's network namespace to a string starting with "container_prefix".

--- a/schema/TenantNetwork.yaml
+++ b/schema/TenantNetwork.yaml
@@ -5,7 +5,7 @@ apiVersion: danm.k8s.io/v1
 # This results in the following characteristics:
 # - TenantNetworks are expected to be freely provisioned by the user the tenant belongs to
 # - Cluster specific networking attributes (VLAN ID, VxLAN ID, name of host NICs, backend associated CNI config files) are automatically associated to TenantNetworks based on the configuration provided by the cluster's network administrator
-# - Cluster specific networking attributes (VLAN ID, VxLAN ID, name of host NICs, backend associated CNI config files) cannot be set, or changed by the tenant user
+# - Cluster specific networking attributes (VLAN ID, VxLAN ID, name of host NICs, backend associated CNI config files) cannot be freely set, or changed by the tenant user
 # DANM can connect Pods to TenantNetworks of the same tenant (namespace).
 kind: TenantNetwork
 metadata:
@@ -18,9 +18,9 @@ metadata:
 spec:
   # This parameter provides a second identifier for TenantNetworks, and can be used to control a number of API features.
   # For static delegates, the parameter configures which CNI configuration file is to be used if NetworkType points to a static-level CNI backend.
-  # For dynamic delegates, VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
+  # VxLAN host interfaces are suffixed, while VLAN host interfaces are prefixed with the NetworkID.
   # This allows deployment administrators to separate their own interfaces from others' in a multi-tenant environment, i.e. by setting NetworkID to "name_namespace" value.
-  # OPTIONAL - STRING, MAXIMUM 12 CHARACTERS
+  # OPTIONAL - STRING, MAXIMUM 11 CHARACTERS
   # IN CASE THE CLUSTER ADMINISTRATOR DEFINED A NETWORKID IN THE USER'S TENANT FOR A SPECIFIC BACKEND, IT WILL OVERWRITE THE USER PROVIDED VALUE.
   NetworkID: ## NETWORK_ID  ##
   # This parameter, denotes which backend is used to provision the container interface connected to this network.
@@ -28,29 +28,35 @@ spec:
   # - IPVLAN option results in an IPVLAN sub-interface provisioned in L2 mode, and connected to the designated host device
   # - SRIOV option pushes a pre-allocated Virtual Function of the configured host device to the container's netns
   # - MACVLAN option results in a MACVLAN sub-interface provisioned in bridge mode, and connected to the designated host device
-  # Setting this option to another value results in delegating the network provisioning operation to the named backend with static configuration (i.e. most Options are ignored).
+  # Setting this option to another value results in delegating the network provisioning operation to the named backend with static configuration (i.e. coming from a standard CNI config file).
   # The default IPVLAN backend is used when this parameter is not specified.
   # OPTIONAL - ONE OF {ipvlan,sriov,macvlan,<NAME_OF_ANY_STATIC_LEVEL_CNI_COMPLIANT_BINARY>}
   # DEFAULT VALUE: ipvlan
   NetworkType: ## BACKEND_TYPE ##
   # Specific extra configuration options can be passed to the network provisioning backends.
-  # Most of the parameters are only supported for dynamic level backends, such as IPVLAN, MACVLAN, and SRIOV.
-  # Other network interfaces are always provisioned based on their associated static CNI configuration files.
-  # The exceptional attributes are "rt_tables", "container_prefix", and "routes/6". DANM universally supports the features related to these parameters for all CNI backends.
+  # Most of the parameters are generally supported for all network types.
+  # Options only supported for dynamic level backends, such as IPVLAN, MACVLAN, and SRIOV are explicitly noted.
   Options:
+    # Name of the parent host device (i.e. physical host NIC).
+    # Sub-interfaces are connected to this NIC in case NetworkType is set to IPVLAN, or MACVLAN.
+    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
+    # Also ignored for SR-IOV, as the pre-allocated Virtual Functions belonging to a configured Kubernetes Device pool are pushed into the connecting Pod's network namespace, regardless which Physical Funtion they belong to.
+    # DANM automatically chooses one of the configured tenant interface profiles when this parameter is left empty.
+    # If defined, DANM chooses the interface profile with the matching name. If that is not allowed to be used by tenants DANM denies the creation of the network.
+    # OPTIONAL - STRING
+    host_device: ## PARENT_DEVICE_NAME ##
     # Name of a network Device Plugin resource pool
     # The device_pool parameter generally represents the base resource name of the Kubernetes Devices connected to this network.
     # This option is mandatory for TenantNetworks with "NetworkType: sriov", and it represents the K8s Virtual Function Device pool connecting Pods are getting their VFs from.
+    # If defined, DANM chooses the interface profile from the tenant's configuration with the matching name. If that is not allowed to be used by tenants DANM denies the creation of the network.
     # OPTIONAL - STRING
     device_pool: ## DEVICE_PLUGIN_RESOURCE_POOL_MAME ##
     # The IPv4 CIDR notation of the subnet associated with the network.
-    # Pods connecting to this network will get their IPv4 IP from this subnet, if defined.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
+    # Pods connecting to this network get an IPv4 address to their interface from this subnet.
     # OPTIONAL - IPv4 CIDR FORMAT (e.g. "10.0.0.0/24")
     cidr: ## SUBNET_CIDR ##
     # IPv4 allocation will be done according to the narrowed down allocation pool parameter, if defined.
     # Allocation pool must be provided together with "cidr", and shall be included in the subnet range.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
     # If CIDR is provided without defining an allocation pool, it is automatically calculated for the whole netmask (minus the first, and the last IP).
     # The gateway IPs of all the configured IP routes are also automatically reserved from the allocation pool when it is generated.
     # When the network administrator sets the allocation pool, DANM assumes the non-usable IPs (e.g. broadcast IP, gateway IPs etc.) were already discounted.
@@ -58,10 +64,8 @@ spec:
       start: ## FIRST_ASSIGNABLE_IP ##
       end: ## LAST_ASSIGNABLE_IP ##
     # The IPv6 CIDR notation of the subnet associated with the network.
-    # Pods connecting to this network will get their IPv6 addresses from this subnet, if defined.
-    # Only has an effect with dynamically integrated backends. Ignored for other NetworkTypes.
-    # OPTIONAL - IPv6 CIDR FORMAT (e.g. "2001:db8::/45").
-    # NOTE: Netmask of the subnet cannot be higher than /64 (i.e. /65 and upwards).
+    # Pods connecting to this network will get their IPv6s from this subnet, if defined.
+    # OPTIONAL - IPv6 CIDR FORMAT (e.g. "2001:db8::/45"). Netmask of the subnet cannot be higher than /64 (i.e. /65 and upwards).
     net6: ## SUBNET_CIDR ##
     # Interfaces connected to this network are renamed inside the Pod's network namespace to a string starting with "container_prefix".
     # If not provided, DANM uses "eth" as the prefix.

--- a/schema/network_attach.yaml
+++ b/schema/network_attach.yaml
@@ -23,8 +23,6 @@ spec:
       # DANM shall be driven with networking related requirements stated in this JSON formatted field.
       # Each entry listed in danm.k8s.io/interfaces annotation results in a network interface provisioned into every Pod's network namespace created based on this template.
       # The interface is provisioned via the backend specified in the referenced network object (or with DANM's in-built IPVLAN CNI by default).
-      # Please note, that some provisioning options are only relevant for specific dynamic level backends.
-      # For CNIs with only static integration level, Pod-level overwrite options are ignored even if present.
       # MANDATORY - LIST OF REQUIRED NETWORK INTERFACES
       #   One network connection can have the following attributes:
       #   EXACTLY ONE OF THE FOLLOWING NETWORK IDENTIFIER OPTIONS:
@@ -32,15 +30,17 @@ spec:
       #   OPTION2: "tenantNetwork": Name of the TenantNetwork (i.e. ObjectMeta.Name) to which the interface should be connected to.
       #   OPTION3: "clusterNetwork": Name of the ClusterNetwork (i.e. ObjectMeta.Name) to which the interface should be connected to.
       #   "ip": desired IPv4 address assigment scheme.
-      #     Ignored for non-dynamic NetworkTypes.
-      #     OPTIONAL PARAMETER - but either "ip" or "ip6" needs to be present. Presence of either "ip" or "ip6" is MANDATORY
+      #     Mandatory for connecting to networks with dynamic NetowrkTypes, such as IPVLAN, MACVLAN, or SR-IOV.
+      #     Optional for static NetworkTypes. When "ip" is defined for a static network also having Spec.Options.Cidr set, the "ipam" section of its static CNI config file is overwritten by DANM.
+      #     OPTIONAL PARAMETER
       #     Possible values:
       #     - "dynamic": the first free IPv4 address is dynamically allocated from the referenced network's allocation pool
       #     - "## DESIRED_STATIC_IPV4_ADDR_FROM_ALLOCATION_POOL (e.g. "10.10.0.101/24") ##"
       #     - "none": no IPv4 is allocated to the interface
       #   "ip6": desired IPv6 address assigment scheme.
-      #     Ignored for non-dynamic NetworkTypes.
-      #     OPTIONAL PARAMETER - but either "ip" or "ip6" needs to be present. Presence of either "ip" or "ip6" is MANDATORY
+      #     Mandatory for connecting to networks with dynamic NetowrkTypes, such as IPVLAN, MACVLAN, or SR-IOV.
+      #     Optional for static NetworkTypes. When "ip6" is defined for a static network also having Spec.Options.Net6 set, the "ipam" section of its static CNI config file is overwritten by DANM.
+      #     OPTIONAL PARAMETER
       #     Possible values:
       #     - "dynamic": a random, free IPv6 address is dynamically allocated from the referenced network's net6 CIDR
       #     - "## DESIRED_STATIC_IPV6_ADDR_FROM_NET6 ##"

--- a/test/stubs/danm/client_stub.go
+++ b/test/stubs/danm/client_stub.go
@@ -25,10 +25,14 @@ type Reservation struct {
 
 type ClientStub struct {
   Objects TestArtifacts
+  NetClient *NetClientStub
 }
 
 func (client *ClientStub) DanmNets(namespace string) client.DanmNetInterface {
-  return newNetClientStub(client.Objects.TestNets, client.Objects.ReservedIps)
+  if client.NetClient == nil {
+    client.NetClient = newNetClientStub(client.Objects.TestNets, client.Objects.ReservedIps)
+  }
+  return client.NetClient 
 }
 
 func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {

--- a/test/stubs/danm/clientset_stub.go
+++ b/test/stubs/danm/clientset_stub.go
@@ -6,15 +6,15 @@ import (
 )
 
 type ClientSetStub struct {
-  danmClient *ClientStub
+  DanmClient *ClientStub
 }
 
 func (c *ClientSetStub) DanmV1() danmv1.DanmV1Interface {
-  return c.danmClient
+  return c.DanmClient
 }
 
 func (c *ClientSetStub) Danm() danmv1.DanmV1Interface {
-  return c.danmClient
+  return c.DanmClient
 }
 
 func (c *ClientSetStub) Discovery() discovery.DiscoveryInterface {
@@ -23,6 +23,6 @@ func (c *ClientSetStub) Discovery() discovery.DiscoveryInterface {
 
 func NewClientSetStub(objects TestArtifacts) *ClientSetStub {
   var clientSet ClientSetStub
-  clientSet.danmClient = newClientStub(objects)
+  clientSet.DanmClient = newClientStub(objects)
   return &clientSet
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -7,6 +7,7 @@ import (
   "github.com/nokia/danm/pkg/bitarray"
   "github.com/nokia/danm/pkg/ipam"
   "github.com/nokia/danm/pkg/admit"
+  stubs "github.com/nokia/danm/test/stubs/danm"
 )
 
 const (
@@ -37,7 +38,7 @@ func SetupAllocationPools(nets []danmtypes.DanmNet) error {
       if dnet.Spec.Options.Pool.End == "" {
         dnet.Spec.Options.Pool.End = (ipam.Int2ip(ipam.Ip2int(admit.GetBroadcastAddress(ipnet)) - 1)).String()
       }
-      if strings.HasPrefix(dnet.Spec.NetworkID, "full") {
+      if strings.HasPrefix(dnet.ObjectMeta.Name, "full") {
         exhaustNetwork(&dnet)
       }
       nets[index].Spec = dnet.Spec
@@ -53,6 +54,16 @@ func GetTestNet(netId string, testNets []danmtypes.DanmNet) *danmtypes.DanmNet {
     }
   }
   return nil
+}
+
+func CreateExpectedAllocationsList(ip string, isExpectedToBeSet bool, networkId string) []stubs.ReservedIpsList {
+  var ips []stubs.ReservedIpsList
+  if ip != "" {
+    reservation := stubs.Reservation {Ip: ip, Set: isExpectedToBeSet,}
+    expectedAllocation := stubs.ReservedIpsList{NetworkId: networkId, Reservations: []stubs.Reservation {reservation,},}
+    ips = append(ips, expectedAllocation)
+  }
+  return ips
 }
 
 func exhaustNetwork(netInfo *danmtypes.DanmNet) {

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -107,7 +107,7 @@ var expectedCniConfigs = []CniConf {
   {"sriov-l3", []byte(`{"cniexp":{"cnitype":"sriov","ip":"192.168.1.65/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"sriov-test","type":"sriov","master":"enp175s0f1","l2enable":false,"vlan":500,"deviceID":"0000:af:06.0","ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
   {"sriov-l2", []byte(`{"cniexp":{"cnitype":"sriov","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"sriov-test","type":"sriov","master":"enp175s0f1","l2enable":true,"vlan":500,"deviceID":"0000:af:06.0"}}`)},
   {"deleteflannel", []byte(`{"cniexp":{"cnitype":"flannel","env":{"CNI_COMMAND":"DEL","CNI_IFNAME":"eth0"}},"cniconf":{"name":"cbr0","type":"flannel","delegate":{"hairpinMode":true,"isDefaultGateway":true}}}`)},
-  {"deletemacvlan", []byte(`{"cniexp":{"cnitype":"macvlan","env":{"CNI_COMMAND":"DEL","CNI_IFNAME":"ens1f0"}},"cniconf":{"cniVersion":"0.3.1","master":"ens1f0","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam"}}}`)},
+  {"deletemacvlan", []byte(`{"cniexp":{"cnitype":"macvlan","env":{"CNI_COMMAND":"DEL","CNI_IFNAME":"ens1f0"}},"cniconf":{"cniVersion":"0.3.1","master":"ens1f0","mode":"bridge","mtu":1500}}`)},
 }
 
 var testCniConfFiles = []CniConf {

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -2,6 +2,7 @@ package ipam_test
 
 import (
   "os"
+  "strconv"
   "strings"
   "testing"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
@@ -17,10 +18,11 @@ var testNets = []danmtypes.DanmNet {
   danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "fullIpv4"},Spec: danmtypes.DanmNetSpec{NetworkID: "fullIpv4", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.0/30"}}},
   danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "net6"},Spec: danmtypes.DanmNetSpec{NetworkID: "net6", Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64", Cidr: "192.168.1.64/26",}}},
   danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "smallNet6"},Spec: danmtypes.DanmNetSpec{NetworkID: "smallNet6", Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/69"}}},
-  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflict"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflict", Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64"}}},
-  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflicterror"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterror", Options: danmtypes.DanmNetOption{Net6: "2a00:8a00:a000:1193::/64"}}},
-  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflictFree"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflictFree", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
-  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflicterrorFree"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterrorFree", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflict"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflict", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "conflicterror"},Spec: danmtypes.DanmNetSpec{NetworkID: "conflicterror", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "fullconflictFree"},Spec: danmtypes.DanmNetSpec{NetworkID: "fullconflictFree", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "fullconflicterrorFree"},Spec: danmtypes.DanmNetSpec{NetworkID: "fullconflicterrorFree", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
+  danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "fullerror"},Spec: danmtypes.DanmNetSpec{NetworkID: "error", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
   danmtypes.DanmNet {ObjectMeta: meta_v1.ObjectMeta {Name: "error"},Spec: danmtypes.DanmNetSpec{NetworkID: "error", Options: danmtypes.DanmNetOption{Cidr: "192.168.1.64/26"}}},
 }
 
@@ -33,36 +35,37 @@ var reserveTcs = []struct {
   expectedIp6 string
   isErrorExpected bool
   isMacExpected bool
+  timesUpdateShouldBeCalled int
 }{
-  {"noIpsRequested", 0, "", "", "", "", false, true},
-  {"noneIPv4", 0, "none", "", "", "", false, true},
-  {"noneIPv6", 0, "", "none", "", "", false, true},
-  {"noneDualStack", 0, "none", "none", "", "", false, true},
-  {"dynamicErrorIPv4", 0, "dynamic", "", "", "", true, false},
-  {"dynamicErrorIPv6", 0, "", "dynamic", "", "", true, false},
-  {"dynamicErrorDualStack", 0, "dynamic", "dynamic", "", "", true, false},
-  {"dynamicIPv4Success", 1, "dynamic", "", "192.168.1.65/26", "", false, true},
-  {"dynamicIPv4Exhausted", 2, "dynamic", "", "", "", true, false},
-  {"staticInvalidIPv4", 2, "hululululu", "", "", "", true, false},
-  {"staticInvalidNoCidrIPv4", 2, "192.168.1.1", "", "", "", true, false},
-  {"staticL2IPv4", 0, "192.168.1.1/26", "", "", "", true, false},
-  {"staticNetmaskMismatchIPv4", 2, "192.168.1.1/32", "", "", "", true, false},
-  {"staticAlreadyUsedIPv4", 2, "192.168.1.2/30", "", "", "", true, false},
-  {"staticSuccessLastIPv4", 1, "192.168.1.126/26", "", "192.168.1.126/26", "", false, true},
-  {"staticSuccessFirstIPv4", 1, "192.168.1.65/26", "", "192.168.1.65/26", "", false, true},
-  {"staticFailAfterLastIPv4", 1, "192.168.1.127/26", "", "", "", true, false},
-  {"staticFailBeforeFirstIPv4", 1, "192.168.1.64/26", "", "", "", true, false},
-  {"dynamicIPv6Success", 3, "", "dynamic", "", "2a00:8a00:a000:1193", false, true},
-  {"dynamicNotSupportedCidrSizeIPv6", 4, "", "dynamic", "", "", true, false}, //basically anything smaller than /64. Restriction must be fixed some day!
-  {"staticL2IPv6", 2, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "", true, false},
-  {"staticInvalidIPv6", 3, "", "2a00:8a00:a000:1193:hulu:lulu:lulu:lulu/64", "", "", true, false},
-  {"staticNetmaskMismatchIPv6", 3, "", "2a00:8a00:a000:2193:f816:3eff:fe24:e348/64", "", "", true, false},
-  {"staticIPv6Success", 3, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, false},
-  {"dynamicDualStackSuccess", 3, "dynamic", "dynamic", "192.168.1.65/26", "2a00:8a00:a000:1193", false, true},
-  {"staticDualStackSuccess", 3, "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, true},
-  {"resolvedConflictDuringUpdate", 5, "", "dynamic", "", "2a00:8a00:a000:1193", false, true},
-  {"unresolvedConflictDuringUpdate", 6, "", "dynamic", "", "", true, false},
-  {"errorUpdate", 9, "", "dynamic", "", "", true, false},
+  {"noIpsRequested", 0, "", "", "", "", false, true, 0},
+  {"noneIPv4", 0, "none", "", "", "", false, true, 0},
+  {"noneIPv6", 0, "", "none", "", "", false, true, 0},
+  {"noneDualStack", 0, "none", "none", "", "", false, true, 0},
+  {"dynamicErrorIPv4", 0, "dynamic", "", "", "", true, false, 0},
+  {"dynamicErrorIPv6", 0, "", "dynamic", "", "", true, false, 0},
+  {"dynamicErrorDualStack", 0, "dynamic", "dynamic", "", "", true, false, 0},
+  {"dynamicIPv4Success", 1, "dynamic", "", "192.168.1.65/26", "", false, true, 1},
+  {"dynamicIPv4Exhausted", 2, "dynamic", "", "", "", true, false, 0},
+  {"staticInvalidIPv4", 2, "hululululu", "", "", "", true, false, 0},
+  {"staticInvalidNoCidrIPv4", 2, "192.168.1.1", "", "", "", true, false, 0},
+  {"staticL2IPv4", 0, "192.168.1.1/26", "", "", "", true, false, 0},
+  {"staticNetmaskMismatchIPv4", 2, "192.168.1.1/32", "", "", "", true, false, 0},
+  {"staticAlreadyUsedIPv4", 2, "192.168.1.2/30", "", "", "", true, false, 0},
+  {"staticSuccessLastIPv4", 1, "192.168.1.126/26", "", "192.168.1.126/26", "", false, true, 1},
+  {"staticSuccessFirstIPv4", 1, "192.168.1.65/26", "", "192.168.1.65/26", "", false, true, 1},
+  {"staticFailAfterLastIPv4", 1, "192.168.1.127/26", "", "", "", true, false, 0},
+  {"staticFailBeforeFirstIPv4", 1, "192.168.1.64/26", "", "", "", true, false, 0},
+  {"dynamicIPv6Success", 3, "", "dynamic", "", "2a00:8a00:a000:1193", false, true, 0},
+  {"dynamicNotSupportedCidrSizeIPv6", 4, "", "dynamic", "", "", true, false, 0}, //basically anything smaller than /64. Restriction must be fixed some day!
+  {"staticL2IPv6", 2, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "", true, false, 0},
+  {"staticInvalidIPv6", 3, "", "2a00:8a00:a000:1193:hulu:lulu:lulu:lulu/64", "", "", true, false, 0},
+  {"staticNetmaskMismatchIPv6", 3, "", "2a00:8a00:a000:2193:f816:3eff:fe24:e348/64", "", "", true, false, 0},
+  {"staticIPv6Success", 3, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, false, 0},
+  {"dynamicDualStackSuccess", 3, "dynamic", "dynamic", "192.168.1.65/26", "2a00:8a00:a000:1193", false, true, 1},
+  {"staticDualStackSuccess", 3, "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, true, 1},
+  {"resolvedConflictDuringUpdate", 5, "dynamic", "", "192.168.1.65/26", "", false, true, 2},
+  {"unresolvedConflictAfterUpdate", 6, "dynamic", "", "", "", true, false, 1},
+  {"errorUpdate", 10, "dynamic", "", "", "", true, false, 1},
 }
 
 var freeTcs = []struct {
@@ -70,17 +73,18 @@ var freeTcs = []struct {
   netIndex int
   allocatedIp string
   isErrorExpected bool
+  timesUpdateShouldBeCalled int
 }{
-  {"l2Network", 0, "192.168.1.126/26", false},
-  {"noAssignedIp", 1, "", false},
-  {"successfulFree", 2, "192.168.1.2/30", false},
-  {"noNetmask", 2, "192.168.1.2", false},
-  {"outOfRange", 2, "192.168.1.10/30", false},
-  {"invalidIp", 2, "192.168.hululu/30", false},
-  {"ipv6", 2, "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false},
-  {"resolvedConflictDuringUpdate", 7, "192.168.1.69/26", false},
-  {"unresolvedConflictDuringUpdate", 8, "192.168.1.69/26", true},
-  {"errorUpdate", 9, "192.168.1.69/26", true},
+  {"l2Network", 0, "192.168.1.126/26", false, 0},
+  {"noAssignedIp", 1, "", false, 0},
+  {"successfulFree", 2, "192.168.1.2/30", false, 1},
+  {"noNetmask", 2, "192.168.1.2", false, 0},
+  {"outOfRange", 2, "192.168.1.10/30", false, 0},
+  {"invalidIp", 2, "192.168.hululu/30", false, 0},
+  {"ipv6", 2, "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, 0},
+  {"resolvedConflictDuringUpdate", 7, "192.168.1.69/26", false, 2},
+  {"unresolvedConflictAfterUpdate", 8, "192.168.1.69/26", true, 1},
+  {"errorUpdate", 9, "192.168.1.69/26", true, 1},
 }
 
 var gcTcs = []struct {
@@ -101,7 +105,7 @@ func TestReserve(t *testing.T) {
   }
   for _, tc := range reserveTcs {
     t.Run(tc.netName, func(t *testing.T) {
-      ips := createExpectedAllocationsList(tc.expectedIp4,true,tc.netIndex)
+      ips := utils.CreateExpectedAllocationsList(tc.expectedIp4,true,testNets[tc.netIndex].Spec.NetworkID)
       testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       ip4, ip6, mac, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
@@ -120,6 +124,13 @@ func TestReserve(t *testing.T) {
       if !strings.HasPrefix(ip6,tc.expectedIp6) {
         t.Errorf("Allocated IP6 address:%s does not prefixed with the expected CIDR:%s", ip6, tc.expectedIp6)
       }
+      var timesUpdateWasCalled int
+      if netClientStub.DanmClient.NetClient != nil {
+        timesUpdateWasCalled = netClientStub.DanmClient.NetClient.TimesUpdateWasCalled
+      }
+      if tc.timesUpdateShouldBeCalled != timesUpdateWasCalled {
+        t.Errorf("Network manifest should have been updated:" + strconv.Itoa(tc.timesUpdateShouldBeCalled) + " times, but it happened:" + strconv.Itoa(timesUpdateWasCalled) + " times instead")
+      }
     })
   }
 }
@@ -131,13 +142,20 @@ func TestFree(t *testing.T) {
   }
   for _, tc := range freeTcs {
     t.Run(tc.netName, func(t *testing.T) {
-      ips := createExpectedAllocationsList(tc.allocatedIp,false,tc.netIndex)
+      ips := utils.CreateExpectedAllocationsList(tc.allocatedIp,false,testNets[tc.netIndex].Spec.NetworkID)
       testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       err := ipam.Free(netClientStub, testNets[tc.netIndex], tc.allocatedIp)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         t.Errorf("Received error:%v does not match with expectation", err)
         return
+      }
+      var timesUpdateWasCalled int
+      if netClientStub.DanmClient.NetClient != nil {
+        timesUpdateWasCalled = netClientStub.DanmClient.NetClient.TimesUpdateWasCalled
+      }
+      if tc.timesUpdateShouldBeCalled != timesUpdateWasCalled {
+        t.Errorf("Network manifest should have been updated:" + strconv.Itoa(tc.timesUpdateShouldBeCalled) + " times, but it happened:" + strconv.Itoa(timesUpdateWasCalled) + " times instead")
       }
     })
   }
@@ -150,23 +168,12 @@ func TestGarbageCollectIps(t *testing.T) {
   }
   for _, tc := range gcTcs {
     t.Run(tc.netName, func(t *testing.T) {
-      ips := createExpectedAllocationsList(tc.allocatedIp4,false,tc.netIndex)
+      ips := utils.CreateExpectedAllocationsList(tc.allocatedIp4,false,testNets[tc.netIndex].Spec.NetworkID)
       testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       ipam.GarbageCollectIps(netClientStub, &testNets[tc.netIndex], tc.allocatedIp4, tc.allocatedIp6)
     })
   }
-}
-
-func createExpectedAllocationsList(ip string, isExpectedToBeSet bool, index int) []stubs.ReservedIpsList {
-  var ips []stubs.ReservedIpsList
-  if ip != "" {
-    strippedIp := strings.Split(ip, "/")
-    reservation := stubs.Reservation {Ip: strippedIp[0], Set: isExpectedToBeSet,}
-    expectedAllocation := stubs.ReservedIpsList{NetworkId: testNets[index].Spec.NetworkID, Reservations: []stubs.Reservation {reservation,},}
-    ips = append(ips, expectedAllocation)
-  }
-  return ips
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Changing IPAM code in cnidel so centralized API driven IPAM now works for all backends requesting it!
All includes static.

If cidr/net6 is included in the network manifest, and the Pod's connection request includes "ip" / "ip6"; DANM will call ipam.Reserve and overwrite the "ipam" key in the CNI config of the static delegate with its own fakeipam integration.
This will result in CNI compliant static backends too getting their IPs purely based on a centralized network management API. 

Also MACVLAN plugin recently was enhanced to tolerate the absence of "ipam" key in the CNI config. As a result "ip":"none" is now enabled for all backends.
The user will be responsible of making sure unsupported IPAM request types are not used for backends not supporting it; and that only CNI standard compliant backends are fed by DANM's IPAM.
