### PR TITLE
Added UTs for admit/netdel.go

### DIFF
--- a/pkg/confman/confman.go
+++ b/pkg/confman/confman.go
@@ -16,7 +16,7 @@ func GetTenantConfig(danmClient danmclientset.Interface) (*danmtypes.TenantConfi
     return nil, err
   }
   if reply == nil || len(reply.Items) == 0 {
-    return nil, errors.New("TenantNetworks cannot be created without provisioning a TenantConfig first!")
+    return nil, errors.New("no TenantConfigs exist int the cluster")
   }
   //TODO: do a namespace based selection later if one generic config does not suffice
   return &reply.Items[0], nil

--- a/test/stubs/danm/client_stub.go
+++ b/test/stubs/danm/client_stub.go
@@ -2,37 +2,21 @@ package danm
 
 import (
   client "github.com/nokia/danm/crd/client/clientset/versioned/typed/danm/v1"
-  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/test/utils"
   rest "k8s.io/client-go/rest"
 )
 
-type TestArtifacts struct {
-  TestNets []danmtypes.DanmNet
-  TestEps []danmtypes.DanmEp
-  ReservedIps []ReservedIpsList
-  TestTconfs []danmtypes.TenantConfig
-}
-
-type ReservedIpsList struct {
-  NetworkId string
-  Reservations []Reservation
-}
-
-type Reservation struct {
-  Ip string
-  Set bool
-}
-
 type ClientStub struct {
-  Objects TestArtifacts
+  Objects utils.TestArtifacts
   NetClient *NetClientStub
+  TconfClient *TconfClientStub
 }
 
 func (client *ClientStub) DanmNets(namespace string) client.DanmNetInterface {
   if client.NetClient == nil {
     client.NetClient = newNetClientStub(client.Objects.TestNets, client.Objects.ReservedIps)
   }
-  return client.NetClient 
+  return client.NetClient
 }
 
 func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {
@@ -40,7 +24,10 @@ func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {
 }
 
 func (client *ClientStub) TenantConfigs() client.TenantConfigInterface {
-  return newTconfClientStub(client.Objects.TestTconfs)
+  if client.TconfClient == nil {
+    client.TconfClient = newTconfClientStub(client.Objects.TestTconfs, client.Objects.ReservedVnis)
+  }
+  return client.TconfClient
 }
 
 func (client *ClientStub) TenantNetworks(namespace string) client.TenantNetworkInterface {
@@ -55,7 +42,7 @@ func (c *ClientStub) RESTClient() rest.Interface {
   return nil
 }
 
-func newClientStub(ta TestArtifacts) *ClientStub {
+func newClientStub(ta utils.TestArtifacts) *ClientStub {
   return &ClientStub {
     Objects: ta,
   }

--- a/test/stubs/danm/clientset_stub.go
+++ b/test/stubs/danm/clientset_stub.go
@@ -3,6 +3,7 @@ package danm
 import (
   discovery "k8s.io/client-go/discovery"
   danmv1 "github.com/nokia/danm/crd/client/clientset/versioned/typed/danm/v1"
+  "github.com/nokia/danm/test/utils"
 )
 
 type ClientSetStub struct {
@@ -21,7 +22,7 @@ func (c *ClientSetStub) Discovery() discovery.DiscoveryInterface {
   return nil
 }
 
-func NewClientSetStub(objects TestArtifacts) *ClientSetStub {
+func NewClientSetStub(objects utils.TestArtifacts) *ClientSetStub {
   var clientSet ClientSetStub
   clientSet.DanmClient = newClientStub(objects)
   return &clientSet

--- a/test/stubs/danm/netclient_stub.go
+++ b/test/stubs/danm/netclient_stub.go
@@ -11,18 +11,20 @@ import (
   "github.com/nokia/danm/pkg/bitarray"
   "github.com/nokia/danm/pkg/datastructs"
   "github.com/nokia/danm/pkg/ipam"
+  "github.com/nokia/danm/test/utils"
 )
+
 const (
   magicVersion = "42"
 )
 
 type NetClientStub struct{
   TestNets []danmtypes.DanmNet
-  ReservedIpsList []ReservedIpsList
+  ReservedIpsList []utils.ReservedIpsList
   TimesUpdateWasCalled int
 }
 
-func newNetClientStub(nets []danmtypes.DanmNet, ips []ReservedIpsList) *NetClientStub {
+func newNetClientStub(nets []danmtypes.DanmNet, ips []utils.ReservedIpsList) *NetClientStub {
   return &NetClientStub{TestNets: nets, ReservedIpsList: ips}
 }
 
@@ -102,6 +104,6 @@ func (netClient *NetClientStub) Patch(name string, pt types.PatchType, data []by
   return nil, nil
 }
 
-func (netClient *NetClientStub) AddReservedIpsList(reservedIps []ReservedIpsList) {
+func (netClient *NetClientStub) AddReservedIpsList(reservedIps []utils.ReservedIpsList) {
   netClient.ReservedIpsList = reservedIps
 }

--- a/test/stubs/danm/tconfclient_stub.go
+++ b/test/stubs/danm/tconfclient_stub.go
@@ -2,42 +2,67 @@ package danm
 
 import (
   "errors"
+  "strconv"
   "strings"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/bitarray"
+  "github.com/nokia/danm/test/utils"
   types "k8s.io/apimachinery/pkg/types"
   watch "k8s.io/apimachinery/pkg/watch"
 )
-  
+
 type TconfClientStub struct{
-  testTconfs []danmtypes.TenantConfig
+  TestTconfs []danmtypes.TenantConfig
+  ReservedVnis []utils.ReservedVnisList
+  TimesUpdateWasCalled int
 }
 
-func newTconfClientStub(tconfs []danmtypes.TenantConfig) TconfClientStub {
-  return TconfClientStub{testTconfs: tconfs}
+func newTconfClientStub(tconfs []danmtypes.TenantConfig, vnis []utils.ReservedVnisList) *TconfClientStub {
+  return &TconfClientStub{TestTconfs: tconfs, ReservedVnis: vnis}
 }
-  
-func (tconfClient TconfClientStub) Create(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
+
+func (tconfClient *TconfClientStub) Create(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
   return nil, nil
 }
 
-func (tconfClient TconfClientStub) Update(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
+func (tconfClient *TconfClientStub) Update(obj *danmtypes.TenantConfig) (*danmtypes.TenantConfig, error) {
+  tconfClient.TimesUpdateWasCalled++
+  for _, vniReservation := range tconfClient.ReservedVnis {
+    for index, hostProfile := range obj.HostDevices {
+      if hostProfile.Name == vniReservation.ProfileName && hostProfile.VniType == vniReservation.VniType {
+        ba := bitarray.NewBitArrayFromBase64(hostProfile.Alloc)
+        for _, reservation := range vniReservation.Reservations {
+          if !ba.Get(uint32(reservation.Vni)) && reservation.Set {
+            return nil, errors.New("Reservation failure, VNI:" + strconv.Itoa(reservation.Vni) + " should have been reserved in TenantConfig:" + obj.ObjectMeta.Name + " profile no:" + strconv.Itoa(index))
+          }
+          if ba.Get(uint32(reservation.Vni)) && !reservation.Set {
+            return nil, errors.New("Reservation failure, VNI:" + strconv.Itoa(reservation.Vni) + " should have been free in TenantConfig:" + obj.ObjectMeta.Name + " profile no.:" + strconv.Itoa(index))
+          }
+        }
+      } else {
+        if hostProfile.Alloc != utils.ExhaustedAllocFor5k {
+          return nil, errors.New("Unexpected VNI was freed in Interface profile named:" + hostProfile.Name)
+        }
+      }
+    }
+  }
   if strings.HasPrefix(obj.ObjectMeta.Name,"error") {
     return nil, errors.New("here you go")
   }
   return &danmtypes.TenantConfig{}, nil
 }
 
-func (tconfClient TconfClientStub) Delete(name string, options *meta_v1.DeleteOptions) error {
+func (tconfClient *TconfClientStub) Delete(name string, options *meta_v1.DeleteOptions) error {
   return nil
 }
 
-func (tconfClient TconfClientStub) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+func (tconfClient *TconfClientStub) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
   return nil
 }
 
-func (tconfClient TconfClientStub) Get(tconfNameName string, options meta_v1.GetOptions) (*danmtypes.TenantConfig, error) {
-  for _, tconf := range tconfClient.testTconfs {
+func (tconfClient *TconfClientStub) Get(tconfNameName string, options meta_v1.GetOptions) (*danmtypes.TenantConfig, error) {
+  for _, tconf := range tconfClient.TestTconfs {
     if tconf.ObjectMeta.Name == tconfNameName {
       return &tconf, nil
     }
@@ -45,23 +70,22 @@ func (tconfClient TconfClientStub) Get(tconfNameName string, options meta_v1.Get
   return nil, nil
 }
 
-func (tconfClient TconfClientStub) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (tconfClient *TconfClientStub) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
   watch := watch.NewEmptyWatch()
   return watch, nil
 }
 
-func (tconfClient TconfClientStub) List(opts meta_v1.ListOptions) (*danmtypes.TenantConfigList, error) {
-  if tconfClient.testTconfs == nil {
+func (tconfClient *TconfClientStub) List(opts meta_v1.ListOptions) (*danmtypes.TenantConfigList, error) {
+  if tconfClient.TestTconfs == nil {
     return nil, nil
   }
-  if strings.HasPrefix(tconfClient.testTconfs[0].ObjectMeta.Name,"error") {
+  if strings.HasPrefix(tconfClient.TestTconfs[0].ObjectMeta.Name,"error") && !strings.Contains(tconfClient.TestTconfs[0].ObjectMeta.Name,"update"){
     return nil, errors.New("error happened")
   }
-  tconfList := danmtypes.TenantConfigList{Items: tconfClient.testTconfs }
+  tconfList := danmtypes.TenantConfigList{Items: tconfClient.TestTconfs }
   return &tconfList, nil
 }
 
-func (tconfClient TconfClientStub) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *danmtypes.TenantConfig, err error) {
+func (tconfClient *TconfClientStub) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *danmtypes.TenantConfig, err error) {
   return nil, nil
 }
-

--- a/test/uts/admit_tests/confadmit_test.go
+++ b/test/uts/admit_tests/confadmit_test.go
@@ -1,13 +1,9 @@
 package admit_tests
 
 import (
-  "bytes"
-  "errors"
   "strings"
   "testing"
   "encoding/json"
-  "io/ioutil"
-  "net/http"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/admit"
   httpstub "github.com/nokia/danm/test/stubs/http"
@@ -15,12 +11,6 @@ import (
   "k8s.io/api/admission/v1beta1"
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-type MalformedTconf struct {
-  HostDevices []danmtypes.IfaceProfile    `json:"hostDevices,omitempty"`
-  NetworkIds  map[string]string `json:"networkIds,omitempty"`
-  ExtraField string             `json:"extraField,omitempty"`
-}
 
 var (
   validateConfs = []danmtypes.TenantConfig {
@@ -183,15 +173,15 @@ func TestValidateTenantConfig(t *testing.T) {
   for _, tc := range validateTconfTcs {
     t.Run(tc.tcName, func(t *testing.T) {
       writerStub := httpstub.NewWriterStub()
-      oldTconf := utils.GetTconf(tc.oldTconfName, validateConfs)
-      newTconf := utils.GetTconf(tc.newTconfName, validateConfs)
-      request,err := createHttpRequest(oldTconf, newTconf, tc.opType)
+      oldTconf, shouldOldMalform := getTestConf(tc.oldTconfName, validateConfs)
+      newTconf, shouldNewMalform := getTestConf(tc.newTconfName, validateConfs)
+      request,err := utils.CreateHttpRequest(oldTconf, newTconf, shouldOldMalform, shouldNewMalform, tc.opType)
       if err != nil {
         t.Errorf("Could not create test HTTP Request object, because:%v", err)
         return
       }
       validator.ValidateTenantConfig(writerStub, request)
-      err = validateHttpResponse(writerStub, tc.isErrorExpected, tc.expectedPatches)
+      err = utils.ValidateHttpResponse(writerStub, tc.isErrorExpected, tc.expectedPatches)
       if err != nil {
         t.Errorf("Received HTTP Response did not match expectation, because:%v", err)
         return
@@ -200,85 +190,15 @@ func TestValidateTenantConfig(t *testing.T) {
   }
 }
 
-func createHttpRequest(oldConf, newConf *danmtypes.TenantConfig, opType v1beta1.Operation) (*http.Request, error) {
-  request := v1beta1.AdmissionRequest{}
-  review := v1beta1.AdmissionReview{Request: &request}
-  if opType != "" {
-    review.Request.Operation = opType
+func getTestConf(name string, confs []danmtypes.TenantConfig) ([]byte, bool) {
+  tconf := utils.GetTconf(name, confs)
+  if tconf == nil {
+    return nil, false
   }
-  var err error
-  if oldConf != nil  {
-    review.Request.OldObject.Raw = canItMalform(oldConf)
+  var shouldItMalform bool
+  if strings.HasPrefix(tconf.ObjectMeta.Name, "malform") {
+    shouldItMalform = true
   }
-  if newConf != nil {
-    review.Request.Object.Raw = canItMalform(newConf)
-  }
-  httpRequest := http.Request{}
-  if oldConf != nil || newConf != nil {
-    rawReview, err := json.Marshal(review)
-    if err != nil {
-      errors.New("AdmissionReview couldn't be Marshalled because:" + err.Error())
-    }
-    reader := bytes.NewReader(rawReview)
-    httpRequest.Body = ioutil.NopCloser(reader)
-  }
-  return &httpRequest, err
-}
-
-func canItMalform(config *danmtypes.TenantConfig) []byte {
-  var bytes []byte
-  if strings.HasPrefix(config.ObjectMeta.Name, "malformed") {
-    malformedConf := MalformedTconf{HostDevices: config.HostDevices, NetworkIds: config.NetworkIds, ExtraField: "blupp"}
-    bytes, _ = json.Marshal(malformedConf)
-  } else {
-    bytes, _ = json.Marshal(config)
-  }
-  return bytes
-}
-
-func validateHttpResponse(writer *httpstub.ResponseWriterStub, isErrorExpected bool, expectedPatches string) error {
-  if writer.RespHeader.Get("Content-Type") != "application/json" {
-    return errors.New("Content-Type is not set to application/json in the HTTP Header")
-  }
-  response, err := writer.GetAdmissionResponse()
-  if err != nil {
-    return err
-  }
-  if isErrorExpected {
-    if response.Allowed {
-      return errors.New("request would have been admitted but we expected an error")
-    }
-    if response.Result.Message == "" {
-      return errors.New("a faulty response was sent without explanation")
-    }
-  } else {
-    if !response.Allowed {
-      return errors.New("request would have been denied but we expected it to pass through validation")
-    }
-    if response.Result != nil {
-      return errors.New("an unnecessary Result message is put into a successful response")
-    }
-  }
-  if expectedPatches != "" {
-     return validatePatches(response, expectedPatches)
-  }
-  return nil
-}
-
-func validatePatches(response *v1beta1.AdmissionResponse, expectedPatches string) error {
-  if expectedPatches == "empty" {
-    if response.Patch != nil {
-      return errors.New("did not expect any patches but some were included in the admission response")
-    }
-    return nil
-  }
-  var patches []admit.Patch
-  err := json.Unmarshal(response.Patch, &patches)
-  if err != nil {
-    return err
-  }
-  if len(patches) != 1 {
-    return errors.New("received number of patches was not the expected 1")
-  }
-  return nil
+  tconfBinary,_ := json.Marshal(tconf)
+  return tconfBinary, shouldItMalform
 }

--- a/test/uts/admit_tests/netdel_test.go
+++ b/test/uts/admit_tests/netdel_test.go
@@ -1,0 +1,167 @@
+package admit_tests
+
+import (
+  "strconv"
+  "strings"
+  "testing"
+  "encoding/json"
+  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  "github.com/nokia/danm/pkg/admit"
+  stubs "github.com/nokia/danm/test/stubs/danm"
+  httpstub "github.com/nokia/danm/test/stubs/http"
+  "github.com/nokia/danm/test/utils"
+  meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+  delNets = []danmtypes.DanmNet {
+    danmtypes.DanmNet {
+      ObjectMeta: meta_v1.ObjectMeta {Name: "malformed"},
+    },
+    danmtypes.DanmNet {
+      ObjectMeta: meta_v1.ObjectMeta {Name: "invalid-type"},
+      TypeMeta: meta_v1.TypeMeta {Kind: "DanmNet"},
+    },
+    danmtypes.DanmNet {
+      ObjectMeta: meta_v1.ObjectMeta {Name: "flannel"},
+      TypeMeta: meta_v1.TypeMeta {Kind: "TenantNetwork"},
+      Spec: danmtypes.DanmNetSpec{NetworkType: "flannel", NetworkID: "flannel"},
+    },
+    danmtypes.DanmNet {
+      ObjectMeta: meta_v1.ObjectMeta {Name: "ipvlan"},
+      TypeMeta: meta_v1.TypeMeta {Kind: "TenantNetwork"},
+      Spec: danmtypes.DanmNetSpec{NetworkType: "ipvlan", NetworkID: "nanomsg", Options: danmtypes.DanmNetOption{Device: "ens4", Vlan: 500}},
+    },
+    danmtypes.DanmNet {
+      ObjectMeta: meta_v1.ObjectMeta {Name: "sriov"},
+      TypeMeta: meta_v1.TypeMeta {Kind: "TenantNetwork"},
+      Spec: danmtypes.DanmNetSpec{NetworkType: "sriov", NetworkID: "e2", Options: danmtypes.DanmNetOption{DevicePool: "nokia.k8s.io/sriov_ens1f1", Vlan: 500}},
+    },
+  }
+  delConf = []danmtypes.TenantConfig {
+    danmtypes.TenantConfig{
+      ObjectMeta: meta_v1.ObjectMeta {Name: "tconf"},
+      HostDevices: []danmtypes.IfaceProfile {
+        danmtypes.IfaceProfile{Name: "ens6", VniType: "vxlan", VniRange: "1200-1300", Alloc: utils.ExhaustedAllocFor5k},
+        danmtypes.IfaceProfile{Name: "nokia.k8s.io/sriov_ens1f0", VniType: "vlan", VniRange: "1500-1550", Alloc: utils.ExhaustedAllocFor5k},},
+    },
+  }
+  errConf = []danmtypes.TenantConfig {
+    danmtypes.TenantConfig{
+      ObjectMeta: meta_v1.ObjectMeta {Name: "errorupdate"},
+      HostDevices: []danmtypes.IfaceProfile {
+        danmtypes.IfaceProfile{Name: "ens4", VniType: "vlan", VniRange: "1200-1300", Alloc: utils.ExhaustedAllocFor5k},
+        danmtypes.IfaceProfile{Name: "nokia.k8s.io/sriov_ens1f0", VniType: "vlan", VniRange: "1500-1550", Alloc: utils.ExhaustedAllocFor5k},},
+    },
+  }
+  validConf = []danmtypes.TenantConfig {
+    danmtypes.TenantConfig{
+      ObjectMeta: meta_v1.ObjectMeta {Name: "tconf"},
+      HostDevices: []danmtypes.IfaceProfile {
+        danmtypes.IfaceProfile{Name: "ens4", VniType: "vxlan", VniRange: "400-500", Alloc: utils.ExhaustedAllocFor5k},
+        danmtypes.IfaceProfile{Name: "ens4", VniType: "vlan", VniRange: "400-500", Alloc: utils.ExhaustedAllocFor5k},
+        danmtypes.IfaceProfile{Name: "nokia.k8s.io/sriov_ens1f0", VniType: "vlan", VniRange: "500-600", Alloc: utils.ExhaustedAllocFor5k},
+        danmtypes.IfaceProfile{Name: "nokia.k8s.io/sriov_ens1f1", VniType: "vlan", VniRange: "500-600", Alloc: utils.ExhaustedAllocFor5k},},
+    },
+  }
+)
+
+var deleteNetworkTcs = []struct {
+  tcName string
+  oldNetName string
+  tconf []danmtypes.TenantConfig
+  isErrorExpected bool
+  shouldVniBeFreed bool
+  expectedPatches string
+  timesUpdateShouldBeCalled int
+}{
+  {"emptyRequest", "", nil, true, false, "empty", 0},
+  {"malformedOldObject", "malformed", nil, true, false, "empty", 0},
+  {"objectWithInvalidType", "invalid-type", nil, false, false, "empty", 0},
+  {"staticNetwork", "flannel", nil, false, false, "empty", 0},
+  {"noTenantConfig", "ipvlan", nil, true, false, "empty", 0},
+  {"missingInterFaceProfile", "ipvlan", delConf, false, false, "empty", 0},
+  {"missingDeviceProfile", "sriov", delConf, false, false, "empty", 0},
+  {"errorUpdating", "ipvlan", errConf, true, true, "empty", 1},
+  {"freeDevice", "ipvlan", validConf, false, true, "empty", 1},
+  {"freeDevicePool", "sriov", validConf, false, true, "empty", 1},
+}
+
+func TestDeleteNetwork(t *testing.T) {
+  validator := admit.Validator{}
+  for _, tc := range deleteNetworkTcs {
+    t.Run(tc.tcName, func(t *testing.T) {
+      defer resetTconf(tc.tconf)
+      writerStub := httpstub.NewWriterStub()
+      oldNet, dnet, shouldOldMalform := getTestNet(tc.oldNetName, delNets)
+      request,err := utils.CreateHttpRequest(oldNet, nil, shouldOldMalform, false, "")
+      if err != nil {
+        t.Errorf("Could not create test HTTP Request object, because:%v", err)
+        return
+      }
+      testArtifacts := utils.TestArtifacts{TestNets: delNets}
+      if tc.shouldVniBeFreed {
+        testArtifacts.ReservedVnis = createVniReservation(dnet, false)
+      } else {
+        testArtifacts.ReservedVnis = createVniReservation(dnet, true)
+      }
+      if tc.tconf != nil {
+        testArtifacts.TestTconfs = tc.tconf
+      }
+      testClient := stubs.NewClientSetStub(testArtifacts)
+      validator.Client = testClient
+      validator.DeleteNetwork(writerStub, request)
+      err = utils.ValidateHttpResponse(writerStub, tc.isErrorExpected, tc.expectedPatches)
+      if err != nil {
+        t.Errorf("Received HTTP Response did not match expectation, because:%v", err)
+        return
+      }
+      var timesUpdateWasCalled int
+      if testClient.DanmClient.TconfClient != nil {
+        timesUpdateWasCalled = testClient.DanmClient.TconfClient.TimesUpdateWasCalled
+      }
+      if tc.timesUpdateShouldBeCalled != timesUpdateWasCalled {
+        t.Errorf("TenantConfig should have been updated:" + strconv.Itoa(tc.timesUpdateShouldBeCalled) + " times, but it happened:" + strconv.Itoa(timesUpdateWasCalled) + " times instead")
+      }
+    })
+  }
+}
+
+func getTestNet(name string, nets []danmtypes.DanmNet) ([]byte, *danmtypes.DanmNet, bool) {
+  dnet := utils.GetTestNet(name, nets)
+  if dnet == nil {
+    return nil, nil, false
+  }
+  var shouldItMalform bool
+  if strings.HasPrefix(dnet.ObjectMeta.Name, "malform") {
+    shouldItMalform = true
+  }
+  dnetBinary,_ := json.Marshal(dnet)
+  return dnetBinary, dnet, shouldItMalform
+}
+
+func createVniReservation(dnet *danmtypes.DanmNet, shouldBeReserved bool) []utils.ReservedVnisList {
+  if dnet == nil {
+    return nil
+  }
+  vni := dnet.Spec.Options.Vlan
+  vniType := "vlan"
+  if vni == 0 {
+    vni = dnet.Spec.Options.Vxlan
+    vniType = "vxlan"
+  }
+  ifaceName := dnet.Spec.Options.Device
+  if ifaceName == "" {
+    ifaceName = dnet.Spec.Options.DevicePool
+  }
+  return utils.CreateExpectedVniAllocationsList(vni, vniType, ifaceName, shouldBeReserved)
+}
+
+func resetTconf(tconf []danmtypes.TenantConfig) {
+  if tconf == nil {
+    return
+  }
+  for index,_ := range tconf[0].HostDevices {
+    tconf[0].HostDevices[index].Alloc = utils.ExhaustedAllocFor5k
+  }
+}

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -345,7 +345,7 @@ func TestDelegateInterfaceSetup(t *testing.T) {
   if err != nil {
     t.Errorf("Test suite could not be set-up because:%s", err.Error())
   }
-  testArtifacts := stubs.TestArtifacts{TestNets: testNets}
+  testArtifacts := utils.TestArtifacts{TestNets: testNets}
   netClientStub := stubs.NewClientSetStub(testArtifacts)
   for _, tc := range delSetupTcs {
     t.Run(tc.tcName, func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestDelegateInterfaceDelete(t *testing.T) {
       testEp := getTestEp(tc.epName)
       testNet := utils.GetTestNet(tc.netName, testNets)
       ips := utils.CreateExpectedAllocationsList(testEp.Spec.Iface.Address,false,testNet.Spec.NetworkID)
-      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      testArtifacts := utils.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       err = setupDelTestTc(tc.cniConfName)
       if err != nil {

--- a/test/uts/confman_test/confman_test.go
+++ b/test/uts/confman_test/confman_test.go
@@ -145,7 +145,7 @@ func TestGetTenantConfig(t *testing.T) {
   for _, tc := range getTconfTcs {
     t.Run(tc.tcName, func(t *testing.T) {
       tconfSet := getTconfSet(tc.tcName, tc.tconfSets.sets)
-      testArtifacts := stubs.TestArtifacts{TestTconfs: tconfSet}
+      testArtifacts := utils.TestArtifacts{TestTconfs: tconfSet}
       tconfClientStub := stubs.NewClientSetStub(testArtifacts)
       tconf, err := confman.GetTenantConfig(tconfClientStub)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
@@ -167,7 +167,7 @@ func TestReserve(t *testing.T) {
       if tc.reserveVnis != nil {
         reserveVnis(&iface,tc.reserveVnis)
       }
-      testArtifacts := stubs.TestArtifacts{TestTconfs: reserveConfs}
+      testArtifacts := utils.TestArtifacts{TestTconfs: reserveConfs}
       tconfClientStub := stubs.NewClientSetStub(testArtifacts)
       vni, err := confman.Reserve(tconfClientStub, tconf, iface)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
@@ -199,7 +199,7 @@ func TestFree(t *testing.T) {
         reserveVnis(&iface,[]int{0,4999})
         tconf.HostDevices[index] = iface
       }
-      testArtifacts := stubs.TestArtifacts{TestTconfs: reserveConfs, TestNets: testNets}
+      testArtifacts := utils.TestArtifacts{TestTconfs: reserveConfs, TestNets: testNets}
       tconfClientStub := stubs.NewClientSetStub(testArtifacts)
       err := confman.Free(tconfClientStub, tconf, dnet)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -106,7 +106,7 @@ func TestReserve(t *testing.T) {
   for _, tc := range reserveTcs {
     t.Run(tc.netName, func(t *testing.T) {
       ips := utils.CreateExpectedAllocationsList(tc.expectedIp4,true,testNets[tc.netIndex].Spec.NetworkID)
-      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      testArtifacts := utils.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       ip4, ip6, mac, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
@@ -143,7 +143,7 @@ func TestFree(t *testing.T) {
   for _, tc := range freeTcs {
     t.Run(tc.netName, func(t *testing.T) {
       ips := utils.CreateExpectedAllocationsList(tc.allocatedIp,false,testNets[tc.netIndex].Spec.NetworkID)
-      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      testArtifacts := utils.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       err := ipam.Free(netClientStub, testNets[tc.netIndex], tc.allocatedIp)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
@@ -169,7 +169,7 @@ func TestGarbageCollectIps(t *testing.T) {
   for _, tc := range gcTcs {
     t.Run(tc.netName, func(t *testing.T) {
       ips := utils.CreateExpectedAllocationsList(tc.allocatedIp4,false,testNets[tc.netIndex].Spec.NetworkID)
-      testArtifacts := stubs.TestArtifacts{TestNets: testNets, ReservedIps: ips}
+      testArtifacts := utils.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       ipam.GarbageCollectIps(netClientStub, &testNets[tc.netIndex], tc.allocatedIp4, tc.allocatedIp6)
     })


### PR DESCRIPTION
We check if the right VNI in the right iface profile was freed, and also check that nothing else was!

Moved the struct definition used by the stubs to util package to avoid circular dependency.