### PR TITLE
Add "categories: all" to all public CRD API definition

### DIFF
--- a/integration/crds/lightweight/DanmNet.yaml
+++ b/integration/crds/lightweight/DanmNet.yaml
@@ -13,6 +13,8 @@ spec:
     shortNames:
     - dn
     - dnet
+    categories:
+    - all
   validation:
     openAPIV3Schema:
       properties:

--- a/integration/crds/production/ClusterNetwork.yaml
+++ b/integration/crds/production/ClusterNetwork.yaml
@@ -13,6 +13,8 @@ spec:
     shortNames:
     - cn
     - cnet
+    categories:
+    - all
   validation:
     openAPIV3Schema:
       properties:

--- a/integration/crds/production/TenantConfig.yaml
+++ b/integration/crds/production/TenantConfig.yaml
@@ -13,3 +13,5 @@ spec:
     shortNames:
     - tc
     - tconf
+    categories:
+    - all

--- a/integration/crds/production/TenantNetwork.yaml
+++ b/integration/crds/production/TenantNetwork.yaml
@@ -13,6 +13,8 @@ spec:
     shortNames:
     - tn
     - tnet
+    categories:
+    - all
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Fixes https://github.com/nokia/danm/issues/112

Note: DanmEp is not meant to be a user-facing API. It only used to store state information internal to DANM.
Therefore we actually don't want DanmEps to show up in generic queries, to avoid overloading the user with unnecessary , and irrelevant information.