### PR TITLE
Provide webhook with certificates in an easy way

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,11 @@ Note2: we assume RBAC is configured for the Kubernetes API, so the manifests inc
  Your bootstrap networking solution can be really anything you fancy!
  We use Flannel for the purpose in our environments, and connect Pods to it with such simple network descriptors like what you can find in **integration/bootstrap_networks**.
 
- **9. Create the webhook Deployment by executing the following command from the project's root directory:**
+ **9. Create the webhook Deployment and provide it with certificates by executing the following commands from the project's root directory:**
  ```
-kubectl create -f integration/manifests/webhook/
+./integration/manifests/webhook/webhook-create-signed-cert.sh
+cat ./integration/manifests/webhook/webhook.yaml | ./integration/manifests/webhook/webhook-patch-ca-bundle.sh > ./integration/manifests/webhook/webhook-ca-bundle.yaml
+kubectl create -f integration/manifests/webhook/webhook-ca-bundle.yaml
 ```
 **Disclaimer**: webhook already leverages DANM CNI to create its network interface. Don't forget to change the name of the network referenced in the example manifest file to your bootstrap network!
 We also assume RBAC is configured in your cluster.

--- a/integration/manifests/webhook/webhook-create-signed-cert.sh
+++ b/integration/manifests/webhook/webhook-create-signed-cert.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    cat <<EOF
+Generate certificate suitable for use with an sidecar-injector webhook service.
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with sidecar-injector webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+The server key/cert k8s CA cert are stored in a k8s secret.
+usage: ${0} [OPTIONS]
+The following flags are required.
+       --service          Service name of webhook.
+       --namespace        Namespace where webhook service and secret reside.
+       --secret           Secret name for CA certificate and server certificate/key pair.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --service)
+            service="$2"
+            shift
+            ;;
+        --secret)
+            secret="$2"
+            shift
+            ;;
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z ${service} ] && service=danm-webhook-svc
+[ -z ${secret} ] && secret=danm-webhook-certs
+[ -z ${namespace} ] && namespace=kube-system
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+tmpdir=$(mktemp -d)
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2>/dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${csrName}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    exit 1
+fi
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+        --from-file=key.pem=${tmpdir}/server-key.pem \
+        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+        --dry-run -o yaml |
+    kubectl -n ${namespace} apply -f -

--- a/integration/manifests/webhook/webhook-patch-ca-bundle.sh
+++ b/integration/manifests/webhook/webhook-patch-ca-bundle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+ROOT=$(cd $(dirname $0)/../../; pwd)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CA_BUNDLE=$(kubectl config view --raw -o json | jq -r '.clusters[0].cluster."certificate-authority-data"' | tr -d '"')
+
+if command -v envsubst >/dev/null 2>&1; then
+    envsubst
+else
+    sed -e "s|\${CA_BUNDLE}|${CA_BUNDLE}|g"
+fi

--- a/integration/manifests/webhook/webhook.yaml
+++ b/integration/manifests/webhook/webhook.yaml
@@ -42,7 +42,7 @@ webhooks:
         namespace: kube-system
         path: "/netvalidation"
       # Configure your pre-generated certificate matching the details of your environment
-      caBundle: <CA_BUNDLE>
+      caBundle: ${CA_BUNDLE}
     rules:
       - operations: ["CREATE","UPDATE"]
         apiGroups: ["danm.k8s.io"]
@@ -56,7 +56,7 @@ webhooks:
         namespace: kube-system
         path: "/confvalidation"
       # Configure your pre-generated certificate matching the details of your environment
-      caBundle: <CA_BUNDLE>
+      caBundle: ${CA_BUNDLE}
     rules:
       - operations: ["CREATE","UPDATE"]
         apiGroups: ["danm.k8s.io"]
@@ -70,7 +70,7 @@ webhooks:
         namespace: kube-system
         path: "/netdeletion"
       # Configure your pre-generated certificate matching the details of your environment
-      caBundle: <CA_BUNDLE>
+      caBundle: ${CA_BUNDLE}
     rules:
       - operations: ["DELETE"]
         apiGroups: ["danm.k8s.io"]
@@ -122,7 +122,7 @@ spec:
       containers:
         - name: danm-webhook
           image: danm_webhook
-          command: [ "/usr/local/bin/webhook", "-tls-cert-bundle=/etc/webhook/certs/danm_webhook.crt", "-tls-private-key-file=/etc/webhook/certs/danm_webhook.key", "bind-port=8443" ]
+          command: [ "/usr/local/bin/webhook", "-tls-cert-bundle=/etc/webhook/certs/cert.pem", "-tls-private-key-file=/etc/webhook/certs/key.pem", "bind-port=8443" ]
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: webhook-certs
@@ -131,5 +131,5 @@ spec:
      # Configure the directory holding the Webhook's server certificates
       volumes:
         - name: webhook-certs
-          hostPath:
-            path: /etc/kubernetes/ssl/
+          secret:
+            secretName: danm-webhook-certs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> bug
> cleanup
> design
> documentation
> failing-test

feature

**What does this PR give to us**:

Added a shell script which generates the cert and key pair for the webook, and puts it in a kubernetes secret, from which the webhook can easily access it.

Added another shell script which provides the CA bundles for the webhook.

Modified the webhook.yaml file to fit the above mentioned changes.

Modified the README.md file to provide instructions on how to use the scripts when setting up the webhook.

**Special notes for your reviewer**: None

**Does this PR introduce a user-facing change?**: Yes
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users need to redeploy the webhook based on the new instructions given in the README.md file.
```
