### PR TITLE
Set verbosity level on info/debug messages to reduce unnecessary logging

### DIFF
--- a/pkg/svccontrol/controller.go
+++ b/pkg/svccontrol/controller.go
@@ -141,7 +141,7 @@ func (c *Controller) processNextWorkItem() bool {
 			return fmt.Errorf("error syncing '%s': %s", key, err.Error())
 		}
 		c.workqueue.Forget(obj)
-		glog.Infof("Successfully synced '%s'", key)
+		glog.V(5).Infof("Successfully synced '%s'", key)
 		return nil
 	}(obj)
 
@@ -347,7 +347,7 @@ func (c *Controller) addDanmep(obj interface{}) {
 	if !c.podSynced() || !c.serviceSynced() || !c.epsSynced() || !c.danmepSynced() {
 		return
 	}
-	glog.Infof("addDanmep is called: %s %s", obj.(*danmv1.DanmEp).GetName(), obj.(*danmv1.DanmEp).GetNamespace())
+	glog.V(5).Infof("addDanmep is called: %s %s", obj.(*danmv1.DanmEp).GetName(), obj.(*danmv1.DanmEp).GetNamespace())
 
 	de := obj.(*danmv1.DanmEp)
 	ipAddr := strings.Split(de.Spec.Iface.Address, "/")[0]
@@ -382,7 +382,7 @@ func (c *Controller) addDanmep(obj interface{}) {
 }
 
 func (c *Controller) updateDanmep(old, new interface{}) {
-	glog.Infof("updateDanmep is called: %s %s", new.(*danmv1.DanmEp).GetName(), new.(*danmv1.DanmEp).GetNamespace())
+	glog.V(5).Infof("updateDanmep is called: %s %s", new.(*danmv1.DanmEp).GetName(), new.(*danmv1.DanmEp).GetNamespace())
 	oldDanmEp := old.(*danmv1.DanmEp)
 	newDanmEp := new.(*danmv1.DanmEp)
 	if oldDanmEp.ResourceVersion == newDanmEp.ResourceVersion {
@@ -393,7 +393,7 @@ func (c *Controller) updateDanmep(old, new interface{}) {
 }
 
 func (c *Controller) delDanmep(obj interface{}) {
-	glog.Infof("updateDanmep is called: %s %s", obj.(*danmv1.DanmEp).GetName(), obj.(*danmv1.DanmEp).GetNamespace())
+	glog.V(5).Infof("delDanmep is called: %s %s", obj.(*danmv1.DanmEp).GetName(), obj.(*danmv1.DanmEp).GetNamespace())
 	de := obj.(*danmv1.DanmEp)
 	ipAddr := strings.Split(de.Spec.Iface.Address, "/")[0]
 	deNs := de.Namespace
@@ -453,11 +453,11 @@ func (c *Controller) addPod(obj interface{}) {
 	if !c.podSynced() || !c.serviceSynced() || !c.epsSynced() || !c.danmepSynced() {
 		return
 	}
-	glog.Infof("addPod is called: %s %s", obj.(*corev1.Pod).GetName(), obj.(*corev1.Pod).GetNamespace())
+	glog.V(5).Infof("addPod is called: %s %s", obj.(*corev1.Pod).GetName(), obj.(*corev1.Pod).GetNamespace())
 }
 
 func (c *Controller) updatePod(old, new interface{}) {
-	glog.Infof("updatePod is called: %s %s", new.(*corev1.Pod).GetName(), new.(*corev1.Pod).GetNamespace())
+	glog.V(5).Infof("updatePod is called: %s %s", new.(*corev1.Pod).GetName(), new.(*corev1.Pod).GetNamespace())
 	oldPod := old.(*corev1.Pod)
 	newPod := new.(*corev1.Pod)
 	if oldPod.ResourceVersion == newPod.ResourceVersion {
@@ -511,7 +511,7 @@ func (c *Controller) updatePod(old, new interface{}) {
 
 func (c *Controller) delPod(obj interface{}) {
 	// pod deletion is handled by cni where danmep is involved, no action is needed
-	glog.Infof("delPod is called: %s %s", obj.(*corev1.Pod).GetName(), obj.(*corev1.Pod).GetNamespace())
+	glog.V(5).Infof("delPod is called: %s %s", obj.(*corev1.Pod).GetName(), obj.(*corev1.Pod).GetNamespace())
 }
 
 ///////////////////////////
@@ -523,7 +523,7 @@ func (c *Controller) addSvc(obj interface{}) {
 	if !c.podSynced() || !c.serviceSynced() || !c.epsSynced() || !c.danmepSynced() {
 		return
 	}
-	glog.Infof("addSvc is called: %s %s", obj.(*corev1.Service).GetName(), obj.(*corev1.Service).GetNamespace())
+	glog.V(5).Infof("addSvc is called: %s %s", obj.(*corev1.Service).GetName(), obj.(*corev1.Service).GetNamespace())
 	svc := obj.(*corev1.Service)
 	svcNs := svc.Namespace
 	svcName := svc.Name
@@ -552,7 +552,7 @@ func (c *Controller) addSvc(obj interface{}) {
 }
 
 func (c *Controller) updateSvc(old, new interface{}) {
-	glog.Infof("updateSvc is called: %s %s", new.(*corev1.Service).GetName(), new.(*corev1.Service).GetNamespace())
+	glog.V(5).Infof("updateSvc is called: %s %s", new.(*corev1.Service).GetName(), new.(*corev1.Service).GetNamespace())
 	oldSvc := old.(*corev1.Service)
 	newSvc := new.(*corev1.Service)
 	if oldSvc.ResourceVersion == newSvc.ResourceVersion || !SvcChanged(oldSvc, newSvc) {
@@ -562,7 +562,7 @@ func (c *Controller) updateSvc(old, new interface{}) {
 }
 
 func (c *Controller) delSvc(obj interface{}) {
-	glog.Infof("delSvc is called: %s %s", obj.(*corev1.Service).GetName(), obj.(*corev1.Service).GetNamespace())
+	glog.V(5).Infof("delSvc is called: %s %s", obj.(*corev1.Service).GetName(), obj.(*corev1.Service).GetNamespace())
 }
 
 ///////////////////////////
@@ -574,11 +574,11 @@ func (c *Controller) addEps(obj interface{}) {
 	if !c.podSynced() || !c.serviceSynced() || !c.epsSynced() || !c.danmepSynced() {
 		return
 	}
-	glog.Infof("addEps is called: %s %s", obj.(*corev1.Endpoints).GetName(), obj.(*corev1.Endpoints).GetNamespace())
+	glog.V(5).Infof("addEps is called: %s %s", obj.(*corev1.Endpoints).GetName(), obj.(*corev1.Endpoints).GetNamespace())
 }
 
 func (c *Controller) updateEps(old, new interface{}) {
-	glog.Infof("updateEps is called: %s %s", new.(*corev1.Endpoints).GetName(), new.(*corev1.Endpoints).GetNamespace())
+	glog.V(5).Infof("updateEps is called: %s %s", new.(*corev1.Endpoints).GetName(), new.(*corev1.Endpoints).GetNamespace())
 	oldEps := old.(*corev1.Endpoints)
 	newEps := new.(*corev1.Endpoints)
 	if oldEps.ResourceVersion == newEps.ResourceVersion {
@@ -587,5 +587,5 @@ func (c *Controller) updateEps(old, new interface{}) {
 }
 
 func (c *Controller) delEps(obj interface{}) {
-	glog.Infof("delEps is called: %s %s", obj.(*corev1.Endpoints).GetName(), obj.(*corev1.Endpoints).GetNamespace())
+	glog.V(5).Infof("delEps is called: %s %s", obj.(*corev1.Endpoints).GetName(), obj.(*corev1.Endpoints).GetNamespace())
 }


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**What does this PR give to us**:
Currently svcwatcher is very noisy. It generates too many log entries, because all the function calls are logged. This PR sets the verbosity level of these info/debug messages to 5, so they will be suppressed by default. Such detailed logging can be enabled by `-v=5` commandline parameter.

**Which issue(s) this PR fixes**
Fixes #14 

**Special notes for your reviewer**:
I know that you have plans to replace glog to something better, but this fix is kindof urgent to reduce fluentd load and save log data store capacity.

**Does this PR introduce a user-facing change?**:
NONE