### PR TITLE
Expanding documentation and examples related to handling IP routes

### DIFF
--- a/example/routes_and_proutes/cnet_with_route.yaml
+++ b/example/routes_and_proutes/cnet_with_route.yaml
@@ -1,0 +1,17 @@
+apiVersion: danm.k8s.io/v1 
+kind: ClusterNetwork
+metadata:
+  name: network-with-route
+spec:
+  NetworkID: routed-net
+  NetworkType: ipvlan
+  Options:
+    host_device: bond0
+    cidr: 10.0.0.0/24 
+    allocation_pool:
+      start: 10.0.0.1
+      end: 10.0.0.10
+    container_prefix: eth0
+    rt_tables: 10
+    routes:
+      10.0.1.0/24: 10.0.0.65

--- a/example/routes_and_proutes/output.txt
+++ b/example/routes_and_proutes/output.txt
@@ -1,0 +1,5 @@
+$ kubectl exec routed-deployment-7bb98d6f97-j7z7n ip r
+10.0.0.0/24 dev eth0 scope link  src 10.0.0.1
+10.0.1.0/24 via 10.0.0.65 dev eth0
+$ kubectl exec routed-deployment-7bb98d6f97-j7z7n ip route show table 10
+10.10.1.0/24 via 10.0.0.65 dev eth0

--- a/example/routes_and_proutes/pod_with_proutes.yaml
+++ b/example/routes_and_proutes/pod_with_proutes.yaml
@@ -1,18 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: external-client
-  namespace: external-client
+  name: routed-deployment
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: external-client
+        app: routed
       annotations:
         danm.k8s.io/interfaces: |
           [
-            {"network":"external", "ip":"dynamic"}
+            {"clusterNetwork":"network-with-route", "ip":"dynamic", "proutes":{"10.10.1.0/24": "10.0.0.65"}}
           ]
     spec:
       containers:

--- a/example/svcwatcher_demo/deployments/internal_processor.yaml
+++ b/example/svcwatcher_demo/deployments/internal_processor.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       containers:
       - name: busybox
+        imagePullPolicy: IfNotPresent
         image: busybox:latest
         args:
         - sleep

--- a/example/svcwatcher_demo/deployments/loadbalancer.yaml
+++ b/example/svcwatcher_demo/deployments/loadbalancer.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       containers:
       - name: busybox
+        imagePullPolicy: IfNotPresent
         image: busybox:latest
         args:
         - sleep

--- a/schema/network_attach.yaml
+++ b/schema/network_attach.yaml
@@ -48,11 +48,11 @@ spec:
       #   "proutes": list of policy-based IPv4 routes to be added to the configured routing table of this interface.
       #     Generally supported parameter, works with all NetworkTypes.
       #     OPTIONAL PARAMETER
-      #     possible value: {"DESTINATION_IPV4_CIDR1:IPV4_GW1","DESTINATION_IPV4_CIDR2:IPV4_GW2"...}
+      #     possible value: {"DESTINATION_IPV4_CIDR1":"IPV4_GW1","DESTINATION_IPV4_CIDR2":"IPV4_GW2"...}
       #   "proutes6": list of policy-based IPv6 routes to be added to the configured routing table of this interface.
       #     Generally supported parameter, works with all NetworkTypes.
       #     OPTIONAL PARAMETER
-      #     possible value: {"DESTINATION_IPV6_CIDR1:IPV6_GW1","DESTINATION_IPV6_CIDR2:IPV6_GW2"...}
+      #     possible value: {"DESTINATION_IPV6_CIDR1":"IPV6_GW1","DESTINATION_IPV6_CIDR2":"IPV6_GW2"...}
         danm.k8s.io/interfaces: |
           [
             {


### PR DESCRIPTION
How to provision IP routes exactly either into the default, or into a custom routing table inside a Pod are our most ambiguous features according to user feedback.

To address the issue I added couple of examples showcasing these features, and exhibiting the expected result!