### PR TITLE
Explicitly set the Go version used inside the project to 1.12.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 language: go
 
-go: 1.12.x
+go: 1.12.9
   
 services: docker
 

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -7,7 +7,7 @@ echo 'Building DANM builder container'
 docker build --no-cache --tag=danm_builder:1.0 scm/build
 
 echo 'Running DANM build'
-docker run --rm --net=host --name=danm_build -v $GOPATH/bin:/go/bin -v $GOPATH/src:/go/src danm_builder:1.0
+docker run --rm --net=host --name=danm_build -v $GOPATH/bin:/usr/local/go/bin -v $GOPATH/src:/usr/local/go/src danm_builder:1.0
 
 echo 'Cleaning up DANM builder container'
 docker rmi -f danm_builder:1.0

--- a/run_uts.sh
+++ b/run_uts.sh
@@ -7,7 +7,7 @@ echo 'Building DANM UT container'
 docker build --no-cache --tag=danm_ut:1.0 scm/ut
 
 echo 'Running DANM UT'
-docker run --rm --net=host --name=danm_ut -v $GOPATH/bin:/go/bin -v $GOPATH/src:/go/src -v /var/log:/var/log danm_ut:1.0
+docker run --rm --net=host --name=danm_ut -v $GOPATH/bin:/usr/local/go/bin -v $GOPATH/src:/usr/local/go/src -v /var/log:/var/log danm_ut:1.0
 
 echo 'Cleaning up DANM UT container'
 docker rmi -f danm_ut:1.0

--- a/scm/build/Dockerfile
+++ b/scm/build/Dockerfile
@@ -1,17 +1,22 @@
 FROM alpine:latest
 MAINTAINER Levente Kale <levente.kale@nokia.com>
 
-ENV GOPATH /go
+ENV GOPATH=/usr/local/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GO_VERSION 1.12.9
 
 COPY build.sh /build.sh
 
 RUN apk add --no-cache ca-certificates \
  && apk update --no-cache \
  && apk upgrade --no-cache \
- && apk add --no-cache make gcc musl-dev go glide git \
- && mkdir -p $GOPATH/bin \
- && mkdir -p $GOPATH/src \
+ && apk add --no-cache make gcc musl-dev glide git bash curl tar \
+ && mkdir -p ${GOPATH} \
+ && mkdir -p ${GOPATH}/bin \
+ && mkdir -p ${GOPATH}/src \
+ && curl -fsSL -k https://dl.google.com/go/go${GO_VERSION}.src.tar.gz | tar zx --strip-components=1 -C ${GOPATH} \
+ && cd ${GOPATH}/src/ \
+ && ./make.bash \
  && rm -rf /var/cache/apk/* \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/*

--- a/scm/ut/Dockerfile
+++ b/scm/ut/Dockerfile
@@ -1,17 +1,22 @@
 FROM alpine:latest
 MAINTAINER Levente Kale <levente.kale@nokia.com>
 
-ENV GOPATH /go
+ENV GOPATH=/usr/local/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GO_VERSION 1.12.9
 
 COPY run_uts.sh /run_uts.sh
 
 RUN apk add --no-cache ca-certificates \
  && apk update --no-cache \
  && apk upgrade --no-cache \
- && apk add --no-cache make gcc musl-dev go glide git bash \
- && mkdir -p $GOPATH/bin \
- && mkdir -p $GOPATH/src \
+ && apk add --no-cache make gcc musl-dev glide git bash curl tar \
+ && mkdir -p ${GOPATH} \
+ && mkdir -p ${GOPATH}/bin \
+ && mkdir -p ${GOPATH}/src \
+ && curl -fsSL -k https://dl.google.com/go/go${GO_VERSION}.src.tar.gz | tar zx --strip-components=1 -C ${GOPATH} \
+ && cd ${GOPATH}/src/ \
+ && ./make.bash \
  && rm -rf /var/cache/apk/* \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/*


### PR DESCRIPTION
Because of build reproducibility, but also to make sure the recently discovered security issues in the os, and net packages are all fixed in our binaries.