### PR TITLE
Performance improvements to concurrent Pod creations, and deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ buildah bud -t webhook:latest integration/docker/webhook
 ```
 builds the respective containers. Afterwards these containers can be directly integrated into a running Kubernetes cluster!
 ## Deployment
-The method of deploying the whole DANM suite into a Kubernetes cluster is the following.  
+The method of deploying the whole DANM suite into a Kubernetes cluster is the following.
 **1A. Extend the Kubernetes API with the DanmNet and DanmEp CRD objects for a simplified network management experience by executing the following command from the project's root directory:**
 ```
 kubectl create -f integration/crds/lightweight
@@ -586,7 +586,7 @@ Network administrators can configure NetworkType: NetworkID mappings into the Te
 Thus it becomes guaranteed that the tenant user's network will use the right CNI configuration file during Pod creation!
 #### List of validation rules
 ##### DanmNet
-Every CREATE, and PUT DanmNet operation is subject to the following validation rules:
+Every CREATE, and ~~PUT~~ (see [https://github.com/nokia/danm/issues/144](https://github.com/nokia/danm/issues/144)) DanmNet operation is subject to the following validation rules:
 
  1. spec.Options.Cidr must be supplied in a valid IPv4 CIDR notation
  2. all gateway addresses belonging to an entry of spec.Options.Routes  shall be in the defined IPv4 CIDR
@@ -608,7 +608,7 @@ Every CREATE, and PUT DanmNet operation is subject to the following validation r
 
 Not complying with any of these rules results in the denial of the provisioning operation.
 ##### TenantNetwork
-Every CREATE, and PUT TenantNetwork operation is subject to the DanmNet validation rules no. 1-9, 11, 12.
+Every CREATE, and ~~PUT~~ (see [https://github.com/nokia/danm/issues/144](https://github.com/nokia/danm/issues/144)) TenantNetwork operation is subject to the DanmNet validation rules no. 1-9, 11, 12.
 In addition TenantNetwork provisioning has the following extra rules:
 
  1. spec.Options.Vlan cannot be provided
@@ -622,7 +622,7 @@ Every DELETE TenantNetwork operation is subject to the DanmNet validation rule n
 
 Not complying with any of these rules results in the denial of the provisioning operation.
 ##### ClusterNetwork
-Every CREATE, and PUT ClusterNetwork operation is subject to the DanmNet validation rules no. 1-11, 13-14.
+Every CREATE, and ~~PUT~~ (see [https://github.com/nokia/danm/issues/144](https://github.com/nokia/danm/issues/144)) ClusterNetwork operation is subject to the DanmNet validation rules no. 1-11, 13-14.
 
 Every DELETE ClusterNetwork operation is subject to the DanmNet validation rule no.15.
 

--- a/cmd/danm/danm.go
+++ b/cmd/danm/danm.go
@@ -11,9 +11,11 @@ import (
 func main() {
   var err error
   f, err := os.OpenFile("/var/log/danm.log", os.O_RDWR | os.O_CREATE | os.O_APPEND, 0640)
-  if err == nil {
-    log.SetOutput(f)
-    defer f.Close()
+  if err != nil {
+    log.Println("ERROR: cannot create log file, because:" + err.Error())
   }
+  defer f.Close()
+  log.SetOutput(f)
+  log.SetFlags(log.LstdFlags | log.Lmicroseconds)
   skel.PluginMain(metacni.CreateInterfaces, metacni.GetInterfaces, metacni.DeleteInterfaces, datastructs.SupportedCniVersions, "")
 }

--- a/integration/manifests/webhook/webhook.yaml
+++ b/integration/manifests/webhook/webhook.yaml
@@ -44,7 +44,8 @@ webhooks:
       # Configure your pre-generated certificate matching the details of your environment
       caBundle: ${CA_BUNDLE}
     rules:
-      - operations: ["CREATE","UPDATE"]
+      # UPDATE IS TEMPORARILY REMOVED DUE TO:https://github.com/nokia/danm/issues/144
+      - operations: ["CREATE"]
         apiGroups: ["danm.k8s.io"]
         apiVersions: ["v1"]
         resources: ["danmnets","clusternetworks","tenantnetworks"]

--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -20,6 +20,7 @@ const(
   TenantNetworkKind = "TenantNetwork"
   ClusterNetworkKind = "ClusterNetwork"
 )
+
 // NetWatcher represents an object watching the K8s API for changes in all three network management API paths
 // Upon the reception of a notification it handles the related VxLAN/VLAN/RT creation/deletions on the host
 type NetWatcher struct {
@@ -342,7 +343,7 @@ func PutNetwork(danmClient danmclientset.Interface, dnet *danmtypes.DanmNet) (bo
     return wasResourceAlreadyUpdated, errors.New("can't refresh network object because it has an invalid type:" + dnet.TypeMeta.Kind)
   }
   if err != nil {
-    if strings.Contains(err.Error(),datastructs.OptimisticLockErrorMsg) {
+    if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
       wasResourceAlreadyUpdated = true
       return wasResourceAlreadyUpdated, nil
     }

--- a/pkg/syncher/syncher.go
+++ b/pkg/syncher/syncher.go
@@ -3,10 +3,15 @@ package syncher
 import (
   "errors"
   "fmt"
+  "strconv"
   "strings"
   "sync"
   "time"
   "github.com/containernetworking/cni/pkg/types/current"
+)
+
+const (
+  MaximumAllowedTime = 3000
 )
 
 type cniOpResult struct {
@@ -39,8 +44,8 @@ func (synch *Syncher) PushResult(cniName string, opRes error, cniRes *current.Re
 }
 
 func (synch *Syncher) GetAggregatedResult() error {
-  //Time-out Pod creation if a plugin did not provide result within 10 seconds
-  for i := 0; i < 1000; i++ {
+  //Time-out Pod creation if plugins did not provide results within the configured timeframe
+  for i := 0; i < MaximumAllowedTime; i++ {
     if synch.ExpectedNumOfResults > len(synch.CniResults) {
       time.Sleep(10 * time.Millisecond)
       continue
@@ -50,7 +55,7 @@ func (synch *Syncher) GetAggregatedResult() error {
     }
     return nil
   }
-  return errors.New("CNI operation timed-out after 10 seconds")
+  return errors.New("CNI operation timed-out after " + strconv.Itoa(MaximumAllowedTime) + " seconds")
 }
 
 func (synch *Syncher) wasAnyOperationErroneous() bool {

--- a/test/uts/syncher_test/syncher_test.go
+++ b/test/uts/syncher_test/syncher_test.go
@@ -7,8 +7,9 @@ import (
   "github.com/containernetworking/cni/pkg/types/current"
   "github.com/nokia/danm/pkg/syncher"
 )
+
 const (
-  timeout = 10
+  timeout = syncher.MaximumAllowedTime/100
 )
 
 type result struct {


### PR DESCRIPTION
See https://github.com/nokia/danm/issues/144 for the whole story.

I also increased the maximum allowed timeout value for Pod level ADD and DEL operations after a week spent with extensive etcd performance profiling.
Unrelated: you should really upgrade to ETCD 3.14, it is the real deal :)