### PR TITLE
Adding support for Intel Fortville + DPDK use-case

### DIFF
--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -87,7 +87,7 @@ type DanmEpIface struct {
   MacAddress  string            `json:"MacAddress"`
   Proutes     map[string]string `json:"proutes"`
   Proutes6    map[string]string `json:"proutes6"`
-  DeviceID  string              `json:"DeviceID,omitempty"`
+  DeviceID    string            `json:"DeviceID,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1d7eea7c8fe94fb460fead10727227389ddead184b862425f9a6a913ec4b6e94
-updated: 2019-08-06T22:31:42.529643558+02:00
+hash: aa386d47de4210547ee89573057b83178ae6f7f4b1dd1df33f0cde11cf69b228
+updated: 2019-09-27T17:53:22.774886331+02:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: 2bd8b58cf4275aeb086ade613de226773e29e853
@@ -72,8 +72,9 @@ imports:
   - logging
   - types
 - name: github.com/intel/sriov-cni
-  version: 9e4c973b2ac517c64867e33d61aee152d70dc330
+  version: 365c8f8cc1204df84f3e976ea30f113e733ca665
   subpackages:
+  - pkg/types
   - pkg/utils
 - name: github.com/j-keck/arping
   version: 2cf9dc699c5640a7e2c81403a44127bf28033600

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,5 @@ import:
   version: v0.8.1
 - package: github.com/intel/multus-cni
   version: e723aabca8792ddd181167660e252a127a81b073
-- package: github.com/intel/sriov-cni
-  version: 9e4c973b2ac517c64867e33d61aee152d70dc330
-
+- package: github.com/intel/sriov-cni	
+  version: 365c8f8cc1204df84f3e976ea30f113e733ca665

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -67,13 +67,11 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions datastructs.IpamC
   if err != nil {
     return nil, errors.New("failed to get the name of the sriov PF for device "+ ep.Spec.Iface.DeviceID +" due to:" + err.Error())
   }
-  sriovConfig.PfName   = pfname
-  sriovConfig.L2Mode   = true
+  sriovConfig.Master   = pfname
   sriovConfig.Vlan     = netInfo.Spec.Options.Vlan
   sriovConfig.DeviceID = ep.Spec.Iface.DeviceID
   if len(ipamOptions.Ips) > 0 {
     sriovConfig.Ipam   = ipamOptions
-    sriovConfig.L2Mode = false
   }
   rawConfig, err := json.Marshal(sriovConfig)
   if err != nil {

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -62,7 +62,6 @@ func getSriovCniConfig(netInfo *danmtypes.DanmNet, ipamOptions datastructs.IpamC
   sriovConfig.CNIVersion = cniVersion
   sriovConfig.Name       = netInfo.Spec.NetworkID
   sriovConfig.Type       = "sriov"
-  // initialize SriovNet specific fields:
   pfname, err := sriov_utils.GetPfName(ep.Spec.Iface.DeviceID)
   if err != nil {
     return nil, errors.New("failed to get the name of the sriov PF for device "+ ep.Spec.Iface.DeviceID +" due to:" + err.Error())

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -75,10 +75,9 @@ func DelegateInterfaceSetup(netConf *datastructs.NetConf, danmClient danmclients
   if cniResult != nil {
     setEpIfaceAddress(cniResult, &ep.Spec.Iface)
   }
-  err = danmep.CreateRoutesInNetNs(*ep, netInfo)
+  err = danmep.PostProcessInterface(*ep, netInfo)
   if err != nil {
-    // We don't consider this serious error, so we only log a warning about the issue.
-    log.Println("WARNING: Could not create IP routes for CNI:" + cniType + " because:" + err.Error())
+    return nil, errors.New("Post-processing failed for interface:" + ep.Spec.Iface.Name + " because:" + err.Error())
   }
   return cniResult, nil
 }

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -2,6 +2,7 @@ package cnidel
 
 import (
   "github.com/containernetworking/cni/pkg/types"
+  sriov_types "github.com/intel/sriov-cni/pkg/types"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/datastructs"
 )
@@ -17,24 +18,9 @@ type cniBackendConfig struct {
 
 // sriovNet represent the configuration of sriov cni v1.0.0
 type SriovNet struct {
-  types.NetConf
-  // name of the PF since sriov cni v1.0.0
-  PfName string     `json:"master"`
-  // if true then add VF as L2 mode only, IPAM will not be executed
-  L2Mode bool       `json:"l2enable,omitEmpty"`
-  // VLAN ID to assign for the VF
-  Vlan   int        `json:"vlan,omitEmpty"`
+  sriov_types.NetConf
   // IPAM configuration to be used for this network
   Ipam   datastructs.IpamConfig `json:"ipam,omitEmpty"`
-  // Device PCI ID
-  DeviceID string `json:"deviceID"`
-}
-
-// VfInformation is a DeviceInfo descriptor expected by sriov cni v1.0.0
-type VfInformation struct {
-  PCIaddr string `json:"pci_addr"`
-  Pfname  string `json:"pfname"`
-  Vfid    int    `json:"vfid"`
 }
 
 type MacvlanNet struct {

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -93,10 +93,6 @@ func createContainerIface(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, device s
       log.Println("WARNING: sending gARP failed with error:" + err.Error(), ", but we will ignore that for now!")
     }
   }
-  err = addIpRoutes(ep, dnet)
-  if err != nil {
-    return errors.New("IP routes could not be provisioned, because:" + err.Error())
-  }
   return nil
 }
 

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -134,10 +134,10 @@ var expectedCniConfigs = []CniConf {
   {"macvlan-ip4", []byte(`{"cniexp":{"cnitype":"macvlan","ip":"192.168.1.65/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"ens1f0"}},"cniconf":{"cniVersion":"0.3.1","name":"macvlan-v4","master":"ens1f0","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
   {"macvlan-ip6", []byte(`{"cniexp":{"cnitype":"macvlan","ip6":"2a00:8a00:a000:1193::/64","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"ens1f1"}},"cniconf":{"cniVersion":"0.3.1","name":"macvlan-v6","master":"ens1f1","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam"}}}`)},
   {"macvlan-dual-stack", []byte(`{"cniexp":{"cnitype":"macvlan","ip":"192.168.1.65/26","ip6":"2a00:8a00:a000:1193::/64","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"ens1f1"}},"cniconf":{"cniVersion":"0.3.1","name":"macvlan-ds","master":"ens1f1","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
-  {"macvlan-ip4-type020", []byte(`{"cniexp":{"cnitype":"macvlan","ip":"192.168.1.66/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"ens1f0"},"return":"020"},"cniconf":{"cniVersion":"0.3.1","name":"macvlan-v4","master":"ens1f0","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.66/26","version":4}]}}}`)},
+  {"macvlan-ip4-type020", []byte(`{"cniexp":{"cnitype":"macvlan","ip":"192.168.1.65/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"ens1f0"},"return":"020"},"cniconf":{"cniVersion":"0.3.1","name":"macvlan-v4","master":"ens1f0","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
   {"macvlan-ip6-type020", []byte(`{"cniexp":{"cnitype":"macvlan","ip6":"2a00:8a00:a000:1193::/64","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"ens1f1"},"return":"020"},"cniconf":{"cniVersion":"0.3.1","name":"macvlan-v6","master":"ens1f1","mode":"bridge","mtu":1500,"ipam":{"type":"fakeipam"}}}`)},
-  {"sriov-l3", []byte(`{"cniexp":{"cnitype":"sriov","ip":"192.168.1.65/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"sriov-test","type":"sriov","master":"enp175s0f1","l2enable":false,"vlan":500,"deviceID":"0000:af:06.0","ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
-  {"sriov-l2", []byte(`{"cniexp":{"cnitype":"sriov","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"sriov-test","type":"sriov","master":"enp175s0f1","l2enable":true,"vlan":500,"deviceID":"0000:af:06.0"}}`)},
+  {"sriov-l3", []byte(`{"cniexp":{"cnitype":"sriov","ip":"192.168.1.65/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"sriov-test","type":"sriov","master":"enp175s0f1","vlan":500,"deviceID":"0000:af:06.0","ipam":{"type":"fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
+  {"sriov-l2", []byte(`{"cniexp":{"cnitype":"sriov","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"sriov-test","type":"sriov","master":"enp175s0f1","vlan":500,"deviceID":"0000:af:06.0"}}`)},
   {"deleteflannel", []byte(`{"cniexp":{"cnitype":"flannel","env":{"CNI_COMMAND":"DEL","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name":"cbr0","type":"flannel","delegate":{"hairpinMode":true,"isDefaultGateway":true}}}`)},
   {"deletemacvlan", []byte(`{"cniexp":{"cnitype":"macvlan","env":{"CNI_COMMAND":"DEL","CNI_IFNAME":"ens1f0"}},"cniconf":{"cniVersion":"0.3.1","name":"full","master":"ens1f0","mode":"bridge","mtu":1500,"ipam": {"type": "fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
   {"bridge-l3-ip4", []byte(`{"cniexp":{"cnitype":"macvlan","ip":"192.168.1.65/26","env":{"CNI_COMMAND":"ADD","CNI_IFNAME":"eth0"}},"cniconf":{"cniVersion":"0.3.1","name": "mynet","type": "bridge","bridge": "mynet0","isDefaultGateway": true,"forceAddress": false,"ipMasq": true,"hairpinMode": true,"ipam": {"type": "fakeipam","ips":[{"ipcidr":"192.168.1.65/26","version":4}]}}}`)},
@@ -253,12 +253,12 @@ var delSetupTcs = []struct {
   {"dynamicMacvlanDualStack", "macvlan-ds", "dynamicDual", "macvlan-dual-stack", "192.168.1.65", "2a00:8a00:a000:1193", false, 1},
   {"dynamicMacvlanIpv4Type020Result", "macvlan-v4", "dynamicIpv4", "macvlan-ip4-type020", "192.168.1.65", "", false, 1},
   {"dynamicMacvlanIpv6Type020Result", "macvlan-v6", "dynamicIpv6", "macvlan-ip6-type020", "", "2a00:8a00:a000:1193", false, 0},
-  {"dynamicSriovNoDeviceId", "sriov-test", "dynamicIpv4", "", "", "", true, 2},
+  {"dynamicSriovNoDeviceId", "sriov-test", "dynamicIpv4", "", "", "", true, 1},
   {"dynamicSriovL3", "sriov-test", "dynamicIpv4WithDeviceId", "sriov-l3", "", "", false, 1},
   {"dynamicSriovL2", "sriov-test", "noneWithDeviceId", "sriov-l2", "", "", false, 0},
   {"bridgeWithV4Overwrite", "bridge-ipam-ipv4", "simpleIpv4", "bridge-l3-ip4", "", "", false, 1},
   {"bridgeWithV4Add", "bridge-ipam-l2", "simpleIpv4", "bridge-l2-ip4", "", "", false, 1},
-  {"bridgeWithInvalidAdd", "bridge-invalid", "simpleIpv4", "", "", "", true, 2},
+  {"bridgeWithInvalidAdd", "bridge-invalid", "simpleIpv4", "", "", "", true, 1},
   {"bridgeL3OriginalNoCidr", "bridge-noipam", "simpleIpv4", "bridge-l3-orig", "", "", false, 0},
   {"bridgeL3OriginalNoIp", "bridge-ipam-ipv4", "noIps", "bridge-l3-orig", "", "", false, 0},
   {"bridgeL2OriginalNoCidr", "bridge-noipam-l2", "simpleIpv4", "bridge-l2-orig", "", "", false, 0},
@@ -358,6 +358,7 @@ func TestDelegateInterfaceSetup(t *testing.T) {
       testNet := utils.GetTestNet(tc.netName, testNets)
       testEp := getTestEp(tc.epName)
       testEp.Spec.NetworkName = testNet.ObjectMeta.Name
+      testNet = utils.InitAllocPool(testNet)
       cniRes, err := cnidel.DelegateInterfaceSetup(&cniConf,netClientStub,testNet,testEp)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         var detailedErrorMessage string


### PR DESCRIPTION
PR solves bullet point 2 described in https://github.com/nokia/danm/issues/148.

It also makes sure to skip kernel tunings for interfaces which are actually not managed by the kernel.