### PR TITLE
Add "-version" option to all DANM binaries

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,13 +15,12 @@
 
 **How to reproduce it**:
 
-
 **Anything else we need to know?**:
 
 **Environment**:
-- danm version
+- DANM version (use `danm -version`):
 - Kubernetes version (use `kubectl version`):
-- danm configuration:
+- DANM configuration (K8s manifests, kubeconfig files, CNI config file):
 - OS (e.g. from /etc/os-release):
 - Kernel (e.g. `uname -a`):
 - Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Fixes #
 **Special notes for your reviewer**:
 
 **Does this PR introduce a user-facing change?**:
-<!--  
+<!--
 If no, just write "NONE".
 If yes, a release note is required:
 Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,10 @@ Feel free to comment on existing issues, open new ones, or simply send your idea
 We promise that we will be always transparent when communicating with the community, and will respectfully hear each and every idea out!
 In exchange we expect the same behavior from our Contributors.
 
-However, please also note that DANM is already being used in many, vastly differing TelCo production cases. 
+However, please also note that DANM is already being used in many, vastly differing TelCo production cases.
 As a result, the maintainers of the project retain the right of refusing certain contributions, if these would not be compatible with an existing production use-case.
 
-Don't feel discouraged or offended if this would happen to you! 
+Don't feel discouraged or offended if this would happen to you!
 What we can promise is that we will always respectfully and truthfully explore and entertain your reasoning before making a decision, and will always openly and transparently share our own with you in case of a conflict!
 
 ### Getting started
@@ -39,7 +39,7 @@ Keep in mind that the project is:
 
  - written in Golang, so you will need a properly set-up Golang 1.9+  development environment
  - managed by Glide, so you will need to install it on your machine (for the time being)
- 
+
 Once you have the prerequisites, fork our project, code your changes, test your contribution, then start a normal GitHub review process.
 
 Pull requests will be only merged once at least one of the project maintainers approved them.
@@ -54,7 +54,7 @@ Not mandatory, *but highly appreciated:*
 
 When writing Unit Tests we prefer testing the packages through their public interfaces!
 
-We appreciate thorough and detailed commit messages. 
+We appreciate thorough and detailed commit messages.
 
 We are not allergic to the number of commits it took to create a contribution, you are not required to squash and amend your changes all the time.
 However, we require you to break-up big contributions into smaller, functionally coherent pieces. This approach greatly reduces both integration and review efforts!
@@ -64,18 +64,21 @@ The following topics are on our mind right now, so if you are looking for topic 
 We are aiming to adopt the go module style dependency management within our project.
 
 Being a new project, we have not yet integrated the repository to an automated CI system (like Travis).
- 
+
 Increasing UT coverage of existing code is alway appreciated.
 
-Extending the "reach" of the DANM ecosystem is our primary goal! 
-This includes both native, first-class integration of additional CNI plugin interfaces, and integrating more one-network Kubernetes features (e.g. NetworkPolicy) with our DanmNet API. 
+Extending the "reach" of the DANM ecosystem is our primary goal!
+This includes both native, first-class integration of additional CNI plugin interfaces, and integrating more one-network Kubernetes features (e.g. NetworkPolicy) with our DanmNet API.
 
 # Community
 ### Maintainers / core team
-Robert Springer (@rospring)
-Levente Kale (@Levovar)
+Róbert Springer (@rospring)
+Levente Kálé (@Levovar)
 ### Distinguished contributors
-Lengyel Krisztian (@klengyel)
+Lengyel Krisztián (@klengyel)
+Ferenc Tóth (@TothFerenc)
+### Honorable mentions
+@peterszilagyi, @libesz, @visnyei, @CsatariGergely, @clivez, @Fillamug, @janosi
 
 Please keep in mind we live in the CET/CEST timezone!
 

--- a/cmd/danm/danm.go
+++ b/cmd/danm/danm.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+  "flag"
   "log"
   "os"
   "github.com/containernetworking/cni/pkg/skel"
@@ -8,7 +9,18 @@ import (
   "github.com/nokia/danm/pkg/metacni"
 )
 
+var(
+  version, commitHash string
+)
+
 func main() {
+  printVersion := flag.Bool("version", false, "prints Git version information of the binary to standard out")
+  flag.Parse()
+  if *printVersion {
+    log.Println("DANM binary was built from release: " + version)
+    log.Println("DANM binary was built from commit: " + commitHash)
+    return
+  }
   var err error
   f, err := os.OpenFile("/var/log/danm.log", os.O_RDWR | os.O_CREATE | os.O_APPEND, 0640)
   if err != nil {

--- a/cmd/netwatcher/netwatcher.go
+++ b/cmd/netwatcher/netwatcher.go
@@ -9,6 +9,10 @@ import (
   "github.com/nokia/danm/pkg/netcontrol"
 )
 
+var(
+  version, commitHash string
+)
+
 func getClientConfig(kubeConfig *string) (*rest.Config, error) {
   if kubeConfig != nil {
     return clientcmd.BuildConfigFromFlags("", *kubeConfig)
@@ -17,6 +21,13 @@ func getClientConfig(kubeConfig *string) (*rest.Config, error) {
 }
 
 func main() {
+  printVersion := flag.Bool("version", false, "prints Git version information of the binary to standard out")
+  flag.Parse()
+  if *printVersion {
+    log.Println("DANM binary was built from release: " + version)
+    log.Println("DANM binary was built from commit: " + commitHash)
+    return
+  }
   log.SetOutput(os.Stdout)
   log.Println("Starting DANM Watcher...")
   kubeConfig := flag.String("kubeconf", "", "Path to a kube config. Only required if out-of-cluster.")

--- a/cmd/svcwatcher/svcwatcher.go
+++ b/cmd/svcwatcher/svcwatcher.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"log"
 	"time"
 	"os"
 	"fmt"
@@ -22,12 +23,18 @@ import (
 )
 
 var (
-	kubeconfig string
+	kubeconfig, version, commitHash string
 )
 
 func main() {
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	printVersion := flag.Bool("version", false, "prints Git version information of the binary to standard out")
 	flag.Parse()
-
+	if *printVersion {
+		log.Println("DANM binary was built from release: " + version)
+		log.Println("DANM binary was built from commit: " + commitHash)
+		return
+	}
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		glog.Fatalf("Error building kubeconfig: %s", err.Error())
@@ -103,8 +110,3 @@ func createRecorder(kubeClient *kubernetes.Clientset, comp string) record.EventR
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("kube-system")})
 	return eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: comp})
 }
-
-func init() {
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-}
-

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -10,12 +10,22 @@ import (
   "github.com/nokia/danm/pkg/admit"
 )
 
+var(
+  version, commitHash string
+)
+
 func main() {
-  cert := flag.String("tls-cert-bundle", "", "File containing the x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert).")
-  key := flag.String("tls-private-key-file", "", "File containing the x509 private key matching --tls-cert-bundle.")
-  port := flag.Int("bind-port", 8443, "The port on which to serve. Default is 8443.")
-  address := flag.String("bind-address", "", "The IP address on which to listen. Default is all interfaces.")
+  cert := flag.String("tls-cert-bundle", "", "file containing the x509 Certificate for HTTPS. (CA cert, if any, concatenated after server cert).")
+  key := flag.String("tls-private-key-file", "", "file containing the x509 private key matching --tls-cert-bundle.")
+  port := flag.Int("bind-port", 8443, "the port on which to serve. Default is 8443.")
+  address := flag.String("bind-address", "", "the IP address on which to listen. Default is all interfaces.")
+  printVersion := flag.Bool("version", false, "prints Git version information of the binary to standard out")
   flag.Parse()
+  if *printVersion {
+    log.Println("DANM binary was built from release: " + version)
+    log.Println("DANM binary was built from commit: " + commitHash)
+    return
+  }
   if cert == nil || key == nil {
     log.Println("ERROR: Configuring TLS is mandatory, --tls-cert-bundle and --tls-private-key-file cannot be empty!")
     return

--- a/scm/build/build.sh
+++ b/scm/build/build.sh
@@ -14,10 +14,12 @@ go install k8s.io/code-generator/cmd/informer-gen
 deepcopy-gen --alsologtostderr --input-dirs github.com/nokia/danm/crd/apis/danm/v1 -O zz_generated.deepcopy --bounding-dirs github.com/nokia/danm/crd/apis
 client-gen --alsologtostderr --clientset-name versioned --input-base "" --input github.com/nokia/danm/crd/apis/danm/v1 --clientset-path github.com/nokia/danm/crd/client/clientset
 lister-gen --alsologtostderr --input-dirs github.com/nokia/danm/crd/apis/danm/v1 --output-package github.com/nokia/danm/crd/client/listers
-informer-gen --alsologtostderr --input-dirs github.com/nokia/danm/crd/apis/danm/v1 --versioned-clientset-package github.com/nokia/danm/crd/client/clientset/versioned --listers-package github.com/nokia/danm/crd/client/listers --output-package github.com/nokia/danm/crd/client/informers 
-go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/cmd/danm
-go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/cmd/netwatcher
-go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/cmd/fakeipam
-go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/cmd/svcwatcher
-go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/cmd/cnitest
-go install -a -ldflags '-extldflags "-static"' github.com/nokia/danm/cmd/webhook
+informer-gen --alsologtostderr --input-dirs github.com/nokia/danm/crd/apis/danm/v1 --versioned-clientset-package github.com/nokia/danm/crd/client/clientset/versioned --listers-package github.com/nokia/danm/crd/client/listers --output-package github.com/nokia/danm/crd/client/informers
+LATEST_TAG=$(git describe --tags)
+COMMIT_HASH=$(git rev-parse HEAD)
+go install -a -ldflags "-extldflags '-static' -X main.version=${LATEST_TAG} -X main.commitHash=${COMMIT_HASH}" github.com/nokia/danm/cmd/danm
+go install -a -ldflags "-extldflags '-static' -X main.version=${LATEST_TAG} -X main.commitHash=${COMMIT_HASH}" github.com/nokia/danm/cmd/netwatcher
+go install -a -ldflags "-extldflags '-static' -X main.version=${LATEST_TAG} -X main.commitHash=${COMMIT_HASH}" github.com/nokia/danm/cmd/svcwatcher
+go install -a -ldflags "-extldflags '-static' -X main.version=${LATEST_TAG} -X main.commitHash=${COMMIT_HASH}" github.com/nokia/danm/cmd/webhook
+go install -a -ldflags "-extldflags '-static'" github.com/nokia/danm/cmd/fakeipam
+go install -a -ldflags "-extldflags '-static'" github.com/nokia/danm/cmd/cnitest


### PR DESCRIPTION
Solves https://github.com/nokia/danm/issues/143

Simply calling any of the major DANM binaries with the "-version" flag will result in version, and commit hash information printed to standard out.
This information is automatically baked into the binaries by the SCM scripts during linking.

Exact version information will make debugging helluva lot easier!