### PR TITLE
Fixing the handling of parallel TenantConfig Updates in confman

### DIFF
--- a/crd/apis/danm/v1/register.go
+++ b/crd/apis/danm/v1/register.go
@@ -36,6 +36,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ClusterNetworkList{},
 		&TenantNetwork{},
 		&TenantNetworkList{},
+		&TenantConfig{},
+		&TenantConfigList{},
 	)
 	meta_v1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/pkg/confman/confman.go
+++ b/pkg/confman/confman.go
@@ -12,7 +12,7 @@ import (
   "k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
-const(
+const (
   TenantConfigKind = "TenantConfig"
 )
 
@@ -33,7 +33,7 @@ func Reserve(danmClient danmclientset.Interface, tconf *danmtypes.TenantConfig, 
     index := getIfaceIndex(tconf, iface.Name, iface.VniType)
     if index == -1 {
       return 0, errors.New("VNI cannot be reserved because selected interface does not exist. You should call for a tech priest, and start praying to the Omnissiah immediately.")
-    }   
+    }
     chosenVni, newAlloc, err := reserveVni(tconf.HostDevices[index])
     if err != nil {
       return 0, err

--- a/test/stubs/danm/client_stub.go
+++ b/test/stubs/danm/client_stub.go
@@ -25,7 +25,7 @@ func (client *ClientStub) DanmEps(namespace string) client.DanmEpInterface {
 
 func (client *ClientStub) TenantConfigs() client.TenantConfigInterface {
   if client.TconfClient == nil {
-    client.TconfClient = newTconfClientStub(client.Objects.TestTconfs, client.Objects.ReservedVnis)
+    client.TconfClient = newTconfClientStub(client.Objects.TestTconfs, client.Objects.ReservedVnis, client.Objects.ExhaustAllocs)
   }
   return client.TconfClient
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -28,6 +28,7 @@ type TestArtifacts struct {
   ReservedIps []ReservedIpsList
   TestTconfs []danmtypes.TenantConfig
   ReservedVnis []ReservedVnisList
+  ExhaustAllocs []int
 }
 
 type ReservedIpsList struct {
@@ -231,4 +232,12 @@ func exhaustAlloc(alloc string) string {
         ba.Set(uint32(i))
   }
   return ba.Encode()
+}
+
+func ReserveVnis(iface *danmtypes.IfaceProfile, vniRange []int) {
+  allocs := bitarray.NewBitArrayFromBase64(iface.Alloc)
+  for i := vniRange[0]; i <= vniRange[1]; i++ {
+    allocs.Set(uint32(i))
+  }
+  iface.Alloc = allocs.Encode()
 }

--- a/test/uts/confman_test/confman_test.go
+++ b/test/uts/confman_test/confman_test.go
@@ -179,6 +179,8 @@ func TestReserve(t *testing.T) {
       iface := getIface(tc.ifaceName, tc.vniType, reserveIfaces)
       if tc.reserveVnis != nil {
         reserveVnis(&iface,tc.reserveVnis)
+        index, _ := getIfaceFromTconf(tc.ifaceName, tc.vniType, tconf)
+        tconf.HostDevices[index] = iface
       }
       testArtifacts := utils.TestArtifacts{TestTconfs: reserveConfs}
       tconfClientStub := stubs.NewClientSetStub(testArtifacts)


### PR DESCRIPTION
When multiple TenantNetworks are being created / deleted at the same time, some of updates can be rejected by the API server with HTTP 409.
Proper handling in such cases is to refresh the TenantConfig object, and try the update again.

Both Reserve and Free APIs are updated to handle contention the right way.