### PR TITLE
PUT danmep before invoking delegated plugins

### DIFF
--- a/pkg/danmep/danmep.go
+++ b/pkg/danmep/danmep.go
@@ -193,6 +193,19 @@ func PutDanmEp(danmClient danmclientset.Interface, ep danmtypes.DanmEp) error {
   return errors.New("DanmEp creation was supposedly successful, but the object hasn't really appeared within 1 sec")
 }
 
+func UpdateDanmepAddress(danmClient danmclientset.Interface, ep danmtypes.DanmEp) error {
+  tempEp, err := danmClient.DanmV1().DanmEps(ep.Namespace).Get(ep.ObjectMeta.Name, meta_v1.GetOptions{})
+  if err != nil {
+    return errors.New("Could not get DanmEp object from K8s API server due to error:" + err.Error())
+  }
+  tempEp.Spec.Iface = ep.Spec.Iface
+  _, err = danmClient.DanmV1().DanmEps(ep.Namespace).Update(tempEp)
+  if err != nil {
+    return errors.New("Could not update DanmEp object to K8s API server due to error:" + err.Error())
+  }
+  return nil
+}
+
 // ArePodsConnectedToNetwork checks if there are any Pods currently in the system using the particular network.
 // If there is at least, it returns true, and the spec of the first matching DanmEp.
 func ArePodsConnectedToNetwork(client danmclientset.Interface, dnet *danmtypes.DanmNet)(bool, danmtypes.DanmEp, error) {

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -367,6 +367,12 @@ func createDelegatedInterface(syncher *syncher.Syncher, danmClient danmclientset
     syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("DanmEp object could not be created due to error:" + err.Error()), nil)
     return
   }
+  err = danmep.PutDanmEp(danmClient, ep)
+  if err != nil {
+    cnidel.FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("DanmEp object could not be PUT to K8s due to error:" + err.Error()), nil)
+    return
+  }
   delegatedResult,err := cnidel.DelegateInterfaceSetup(DanmConfig, danmClient, netInfo, &ep)
   if err != nil {
     cnidel.FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
@@ -379,10 +385,10 @@ func createDelegatedInterface(syncher *syncher.Syncher, danmClient danmclientset
     syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("Post-processing failed for interface:" + ep.Spec.Iface.Name + " because:" + err.Error()), nil)
     return
   }
-  err = danmep.PutDanmEp(danmClient, ep)
+  err = danmep.UpdateDanmepAddress(danmClient, ep)
   if err != nil {
     cnidel.FreeDelegatedIps(danmClient, netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
-    syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("DanmEp object could not be PUT to K8s due to error:" + err.Error()), nil)
+    syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("DanmEp object could not be UPDATE to K8s due to error:" + err.Error()), nil)
     return
   }
   syncher.PushResult(netInfo.ObjectMeta.Name, nil, delegatedResult)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
 bug
> cleanup
> design
> documentation
> failing-test
> feature

**What does this PR give to us**:
When creating delegated interface, put the danmep into etcd before invoking the delegated plugin, and update the danmep after the invoking finished successfully. So a danmep for this interface can be stored in the etcd even if the invoking is time out.
 
**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #165 

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
None
