### PR TITLE
Change random EUI64 based IPv6 allocation scheme to be allocation pool based

### DIFF
--- a/cmd/cnitest/cnitest.go
+++ b/cmd/cnitest/cnitest.go
@@ -172,7 +172,7 @@ func validateFlannelConfig(receivedCniConfig, expectedCniConfig []byte) error {
 func createCurrentCniResult(tcConf TestConfig) *current.Result {
   cniRes := current.Result {CNIVersion: "0.3.1"}
   if tcConf.CniExpectations.Ip != "" ||  tcConf.CniExpectations.Ip6 != "" {
-    metacni.AddIfaceToResult("eth0", "AA:BB:CC:DD:EE:FF", "hululululu", &cniRes)
+    metacni.AddIfaceToResult("eth0", "hululululu", &cniRes)
   }
   if tcConf.CniExpectations.Ip != "" {
     metacni.AddIpToResult(tcConf.CniExpectations.Ip, "4", &cniRes)

--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -62,12 +62,12 @@ type DanmNetList struct {
 type IpPool struct {
   Start string `json:"start,omitEmpty"`
   End   string `json:"end,omitEmpty"`
+  LastIp string `json:"lastIp,omitEmpty"`
 }
 
 type IpPoolV6 struct {
   IpPool
   Cidr   string `json:"cidr"`
-  LastIp string `json:"lastIp,omitEmpty"`
 }
 
 // +genclient
@@ -94,6 +94,7 @@ type DanmEpIface struct {
   Name        string            `json:"Name"`
   Address     string            `json:"Address"`
   AddressIPv6 string            `json:"AddressIPv6"`
+  //DEPRECATED, WILL BE REMOVED
   MacAddress  string            `json:"MacAddress"`
   Proutes     map[string]string `json:"proutes"`
   Proutes6    map[string]string `json:"proutes6"`

--- a/pkg/bitarray/bitarray.go
+++ b/pkg/bitarray/bitarray.go
@@ -15,15 +15,15 @@ const (
 
 // BitArray is type to represent an arbitrary long array of bits
 type BitArray struct {
-  len int
+  len uint32
   data []byte
 }
 
 // NewBitArray creates a new, empty BitArray object
 // Returns error if length is zero, otherwise a pointer to the array
-func NewBitArray(len int) (*BitArray, error) {
-  if 0 >= len {
-    return nil, errors.New("Can't make a BitArray with a negative length!")
+func NewBitArray(len uint32) (*BitArray, error) {
+  if 0 == len {
+    return nil, errors.New("Can't make a BitArray with zero length!")
   }
   bitArray := &BitArray{len, make([]byte, (len+7)/8)}
   bitArray.Set(0)
@@ -35,7 +35,7 @@ func NewBitArrayFromBase64(text string) *BitArray {
   var tmp []byte
   tmp, _ = b64.StdEncoding.DecodeString(text)
   arr := new(BitArray)
-  arr.len = len(tmp)*8
+  arr.len = uint32(len(tmp))*8
   arr.data = tmp
   return arr
 }
@@ -52,7 +52,7 @@ func CreateBitArrayFromIpnet(ipnet *net.IPNet) (*BitArray,error) {
   if baLength > MaxSupportedAllocLength {
     return nil, errors.New("DANM does not support networks with more than 2^" + strconv.Itoa(MaxSupportedAllocLength) + " IP addresses")
   }
-  bitArray,_ := NewBitArray(int(math.Pow(2,float64(baLength))))
+  bitArray,_ := NewBitArray(uint32(math.Pow(2,float64(baLength))))
   bitArray.Set(uint32(math.Pow(2,float64(baLength))-1))
   return bitArray,nil
 }
@@ -78,7 +78,7 @@ func (arr *BitArray) Encode() string {
 }
 
 // Len returns the length of the BitArray
-func (arr *BitArray) Len() int {
+func (arr *BitArray) Len() uint32 {
   if arr == nil {
     return 0
   }

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -50,7 +50,7 @@ func DelegateInterfaceSetup(netConf *datastructs.NetConf, danmClient danmclients
     ipamOptions datastructs.IpamConfig
   )
   if isIpamNeeded(netInfo, ep) {
-    ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6, _, err = ipam.Reserve(danmClient, *netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6, err = ipam.Reserve(danmClient, *netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
     if err != nil {
       return nil, errors.New("IP address reservation failed for network:" + netInfo.ObjectMeta.Name + " with error:" + err.Error())
     }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -95,7 +95,7 @@ func allocateIps(netInfo *danmtypes.DanmNet, req4, req6 string) (string, string,
   }
   if req6 != "" {
     if netInfo.Spec.Options.Net6 != "" && netInfo.Spec.Options.Pool6.Cidr == "" {
-      initV6AllocFields(netInfo)
+      InitV6AllocFields(netInfo)
     }
     pool6 := danmtypes.IpPool{Start: netInfo.Spec.Options.Pool6.Start, End: netInfo.Spec.Options.Pool6.End}
     netInfo.Spec.Options.Alloc6, ip6, err = allocateAddress(pool6, netInfo.Spec.Options.Alloc6, req6, netInfo.Spec.Options.Pool6.Cidr)
@@ -106,7 +106,7 @@ func allocateIps(netInfo *danmtypes.DanmNet, req4, req6 string) (string, string,
   return ip4, ip6, err
 }
 
-func initV6AllocFields(netInfo *danmtypes.DanmNet) {
+func InitV6AllocFields(netInfo *danmtypes.DanmNet) {
   InitV6PoolCidr(netInfo)
   netInfo.Spec.Options.Pool6.Start, netInfo.Spec.Options.Pool6.End, netInfo.Spec.Options.Alloc6 =
     InitAllocPool(netInfo.Spec.Options.Pool6.Cidr, netInfo.Spec.Options.Pool6.Start, netInfo.Spec.Options.Pool6.End, netInfo.Spec.Options.Alloc6, netInfo.Spec.Options.Routes6)

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -389,7 +389,7 @@ func createDelegatedInterface(syncher *syncher.Syncher, danmClient danmclientset
 }
 
 func createDanmInterface(syncher *syncher.Syncher, danmClient danmclientset.Interface, iface datastructs.Interface, netInfo *danmtypes.DanmNet, args *cniArgs) {
-  ip4, ip6, macAddr, err := ipam.Reserve(danmClient, *netInfo, iface.Ip, iface.Ip6)
+  ip4, ip6, err := ipam.Reserve(danmClient, *netInfo, iface.Ip, iface.Ip6)
   if err != nil {
     syncher.PushResult(netInfo.ObjectMeta.Name, errors.New("IP address reservation failed for network:" + netInfo.ObjectMeta.Name + " with error:" + err.Error()), nil)
     return
@@ -401,7 +401,6 @@ func createDanmInterface(syncher *syncher.Syncher, danmClient danmclientset.Inte
     Name: cnidel.CalculateIfaceName(DanmConfig.NamingScheme, netInfo.Spec.Options.Prefix, iface.DefaultIfaceName, iface.SequenceId),
     Address:     ip4,
     AddressIPv6: ip6,
-    MacAddress:  macAddr,
     Proutes:     iface.Proutes,
     Proutes6:    iface.Proutes6,
   }
@@ -432,7 +431,7 @@ func createDanmInterface(syncher *syncher.Syncher, danmClient danmclientset.Inte
     return
   }
   danmResult := &current.Result{}
-  AddIfaceToResult(ep.Spec.EndpointID, epSpec.MacAddress, args.containerId, danmResult)
+  AddIfaceToResult(ep.Spec.EndpointID, args.containerId, danmResult)
   AddIpToResult(ip4,"4",danmResult)
   AddIpToResult(ip6,"6",danmResult)
   syncher.PushResult(netInfo.ObjectMeta.Name, nil, danmResult)
@@ -480,10 +479,9 @@ func createDanmEp(epInput danmtypes.DanmEpIface, netInfo *danmtypes.DanmNet, arg
   return ep, nil
 }
 
-func AddIfaceToResult(epid string, macAddress string, sandBox string, cniResult *current.Result) {
+func AddIfaceToResult(epid string, sandBox string, cniResult *current.Result) {
   iface := &current.Interface{
     Name: epid,
-    Mac: macAddress,
     Sandbox: sandBox,
   }
   cniResult.Interfaces = append(cniResult.Interfaces, iface)

--- a/test/stubs/danm/netclient_stub.go
+++ b/test/stubs/danm/netclient_stub.go
@@ -47,7 +47,7 @@ func (netClient *NetClientStub) Update(obj *danmtypes.DanmNet) (*danmtypes.DanmN
           _, subnet, _ = net.ParseCIDR(obj.Spec.Options.Pool6.Cidr)
           alloc = obj.Spec.Options.Alloc6
         }
-        if subnet != nil || !subnet.Contains(ip) {
+        if subnet == nil || !subnet.Contains(ip) {
           continue
         }
         isIpSetInBa := isIpSet(ip, subnet, alloc)

--- a/test/uts/bitarray_test/bitarray_test.go
+++ b/test/uts/bitarray_test/bitarray_test.go
@@ -10,12 +10,11 @@ import (
 )
 
 var arraySizeTestConsts = []struct {
-  inputSize int
+  inputSize uint32
   isErrorExpected bool
-  expectedSize int
+  expectedSize uint32
 }{
-  {-1, true, 0},
-  {0, true, 0},
+  {0, false, 0},
   {1, false, 1},
   {33000, false, 33000},
 }
@@ -24,20 +23,20 @@ var createBaFromNetTcs = []struct {
   name string
   subnet string
   isErrorExpected bool
-  expectedSize int
+  expectedSize uint32
 }{
-  {"maxIpV4", "10.0.0.0/9", false, int(math.Pow(2,float64(bitarray.MaxSupportedAllocLength)))},
+  {"maxIpV4", "10.0.0.0/9", false, uint32(math.Pow(2,float64(bitarray.MaxSupportedAllocLength)))},
   {"minIpV4", "192.168.1.50/32", false, 1},
   {"negativeIpV4", "192.168.1.50/33", false, 0},
   {"overTheLimitIpV4", "10.0.0.0/8", true, 0},
-  {"maxIpV6", "2001:db8:85a3::8a2e:370:7334/105", false, int(math.Pow(2,float64(bitarray.MaxSupportedAllocLength)))},
+  {"maxIpV6", "2001:db8:85a3::8a2e:370:7334/105", false, uint32(math.Pow(2,float64(bitarray.MaxSupportedAllocLength)))},
   {"minIpV6", "2001:db8:85a3::8a2e:370:7334/128", false, 1},
   {"overTheLimitIpV6", "2001:db8:85a3::8a2e:370:7334/104", true, 0},  
 }
 
 func TestNewBitArray(t *testing.T) {
   for _, tt := range arraySizeTestConsts {
-    t.Run("TestNewBitArray Size:"+strconv.Itoa(tt.inputSize), func(t *testing.T) {
+    t.Run("TestNewBitArray Size:"+strconv.Itoa(int(tt.inputSize)), func(t *testing.T) {
       testArray, newErr := bitarray.NewBitArray(tt.inputSize)
       err := evalBa(tt.isErrorExpected, newErr, tt.expectedSize, testArray)
       if err != nil {
@@ -89,16 +88,16 @@ func TestCreateBitArrayFromIpnet(t *testing.T) {
   }
 }
 
-func evalBa(isErrorExpected bool, err error, expSize int, testArray *bitarray.BitArray) error {
+func evalBa(isErrorExpected bool, err error, expSize uint32, testArray *bitarray.BitArray) error {
   if (isErrorExpected && nil==err) && (!isErrorExpected && nil!=err) {
-    return errors.New("BitArray initialization returned unexpected error result at test value " + strconv.Itoa(expSize) + ": error expected: " + strconv.FormatBool(isErrorExpected) + ", returned error" + err.Error())
+    return errors.New("BitArray initialization returned unexpected error result at test value " + strconv.Itoa(int(expSize)) + ": error expected: " + strconv.FormatBool(isErrorExpected) + ", returned error" + err.Error())
   }
   if isErrorExpected {
     return nil
   }
   actualSize := testArray.Len()
   if actualSize != expSize {
-    return errors.New("BitArray returned unexpected size: " + strconv.Itoa(actualSize) + ", expected size was:"+ strconv.Itoa(expSize))
+    return errors.New("BitArray returned unexpected size: " + strconv.Itoa(int(actualSize)) + ", expected size was:"+ strconv.Itoa(int(expSize)))
   }
   return nil
 }

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -407,7 +407,8 @@ func TestDelegateInterfaceDelete(t *testing.T) {
     t.Run(tc.tcName, func(t *testing.T) {
       testEp := getTestEp(tc.epName)
       testNet := utils.GetTestNet(tc.netName, testNets)
-      ips := utils.CreateExpectedAllocationsList(testEp.Spec.Iface.Address,false,testNet.Spec.NetworkID)
+      var ips []utils.ReservedIpsList
+      ips = utils.AppendIpToExpectedAllocsList(ips, testEp.Spec.Iface.Address,false,testNet.Spec.NetworkID)
       testArtifacts := utils.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
       err = setupDelTestTc(tc.cniConfName)

--- a/test/uts/cnidel_test/cnidel_test.go
+++ b/test/uts/cnidel_test/cnidel_test.go
@@ -249,10 +249,10 @@ var delSetupTcs = []struct {
   {"staticCniNoBinary", "no-binary", "noIps", "flannel", "", "", true, 0},
   {"staticCniWithIp", "flannel-test", "noIps", "flannel-ip", "10.244.10.30", "", false, 0},
   {"dynamicMacvlanIpv4", "macvlan-v4", "dynamicIpv4", "macvlan-ip4", "192.168.1.65", "", false, 1},
-  {"dynamicMacvlanIpv6", "macvlan-v6", "dynamicIpv6", "macvlan-ip6", "", "2a00:8a00:a000:1193", false, 0},
+  {"dynamicMacvlanIpv6", "macvlan-v6", "dynamicIpv6", "macvlan-ip6", "", "2a00:8a00:a000:1193", false, 1},
   {"dynamicMacvlanDualStack", "macvlan-ds", "dynamicDual", "macvlan-dual-stack", "192.168.1.65", "2a00:8a00:a000:1193", false, 1},
   {"dynamicMacvlanIpv4Type020Result", "macvlan-v4", "dynamicIpv4", "macvlan-ip4-type020", "192.168.1.65", "", false, 1},
-  {"dynamicMacvlanIpv6Type020Result", "macvlan-v6", "dynamicIpv6", "macvlan-ip6-type020", "", "2a00:8a00:a000:1193", false, 0},
+  {"dynamicMacvlanIpv6Type020Result", "macvlan-v6", "dynamicIpv6", "macvlan-ip6-type020", "", "2a00:8a00:a000:1193", false, 1},
   {"dynamicSriovNoDeviceId", "sriov-test", "dynamicIpv4", "", "", "", true, 1},
   {"dynamicSriovL3", "sriov-test", "dynamicIpv4WithDeviceId", "sriov-l3", "", "", false, 1},
   {"dynamicSriovL2", "sriov-test", "noneWithDeviceId", "sriov-l2", "", "", false, 0},
@@ -262,7 +262,7 @@ var delSetupTcs = []struct {
   {"bridgeL3OriginalNoCidr", "bridge-noipam", "simpleIpv4", "bridge-l3-orig", "", "", false, 0},
   {"bridgeL3OriginalNoIp", "bridge-ipam-ipv4", "noIps", "bridge-l3-orig", "", "", false, 0},
   {"bridgeL2OriginalNoCidr", "bridge-noipam-l2", "simpleIpv4", "bridge-l2-orig", "", "", false, 0},
-  {"bridgeWithV6Overwrite", "bridge-ipam-ipv6", "simpleIpv6", "bridge-l3-ip6", "", "", false, 0},
+  {"bridgeWithV6Overwrite", "bridge-ipam-ipv6", "simpleIpv6", "bridge-l3-ip6", "", "", false, 1},
   {"bridgeWithDsOverwrite", "bridge-ipam-ds", "simpleDs", "bridge-l3-ds", "", "", false, 1},
 }
 
@@ -358,7 +358,7 @@ func TestDelegateInterfaceSetup(t *testing.T) {
       testNet := utils.GetTestNet(tc.netName, testNets)
       testEp := getTestEp(tc.epName)
       testEp.Spec.NetworkName = testNet.ObjectMeta.Name
-      testNet = utils.InitAllocPool(testNet)
+      utils.InitAllocPool(testNet)
       cniRes, err := cnidel.DelegateInterfaceSetup(&cniConf,netClientStub,testNet,testEp)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         var detailedErrorMessage string

--- a/test/uts/ipam_test/ipam_test.go
+++ b/test/uts/ipam_test/ipam_test.go
@@ -35,38 +35,37 @@ var reserveTcs = []struct {
   expectedIp4 string
   expectedIp6 string
   isErrorExpected bool
-  isMacExpected bool
   timesUpdateShouldBeCalled int
 }{
-  {"noIpsRequested", 0, "", "", "", "", false, true, 0},
-  {"noneIPv4", 0, "none", "", "none", "", false, true, 0},
-  {"noneIPv6", 0, "", "none", "", "none", false, true, 0},
-  {"noneDualStack", 0, "none", "none", "none", "none", false, true, 0},
-  {"dynamicErrorIPv4", 0, "dynamic", "", "", "", true, false, 0},
-  {"dynamicErrorIPv6", 0, "", "dynamic", "", "", true, false, 0},
-  {"dynamicErrorDualStack", 0, "dynamic", "dynamic", "", "", true, false, 0},
-  {"dynamicIPv4Success", 1, "dynamic", "", "192.168.1.65/26", "", false, true, 1},
-  {"dynamicIPv4Exhausted", 2, "dynamic", "", "", "", true, false, 0},
-  {"staticInvalidIPv4", 2, "hululululu", "", "", "", true, false, 0},
-  {"staticInvalidNoCidrIPv4", 2, "192.168.1.1", "", "", "", true, false, 0},
-  {"staticL2IPv4", 0, "192.168.1.1/26", "", "", "", true, false, 0},
-  {"staticNetmaskMismatchIPv4", 2, "192.168.1.1/32", "", "", "", true, false, 0},
-  {"staticAlreadyUsedIPv4", 2, "192.168.1.2/30", "", "", "", true, false, 0},
-  {"staticSuccessLastIPv4", 1, "192.168.1.126/26", "", "192.168.1.126/26", "", false, true, 1},
-  {"staticSuccessFirstIPv4", 11, "192.168.1.65/26", "", "192.168.1.65/26", "", false, true, 1},
-  {"staticFailAfterLastIPv4", 1, "192.168.1.127/26", "", "", "", true, false, 0},
-  {"staticFailBeforeFirstIPv4", 1, "192.168.1.64/26", "", "", "", true, false, 0},
-  {"dynamicIPv6Success", 3, "", "dynamic", "", "2a00:8a00:a000:1193", false, true, 0},
-  {"dynamicNotSupportedCidrSizeIPv6", 4, "", "dynamic", "", "", true, false, 0}, //basically anything smaller than /64. Restriction must be fixed some day!
-  {"staticL2IPv6", 2, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "", true, false, 0},
-  {"staticInvalidIPv6", 3, "", "2a00:8a00:a000:1193:hulu:lulu:lulu:lulu/64", "", "", true, false, 0},
-  {"staticNetmaskMismatchIPv6", 3, "", "2a00:8a00:a000:2193:f816:3eff:fe24:e348/64", "", "", true, false, 0},
-  {"staticIPv6Success", 3, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, false, 0},
-  {"dynamicDualStackSuccess", 3, "dynamic", "dynamic", "192.168.1.65/26", "2a00:8a00:a000:1193", false, true, 1},
-  {"staticDualStackSuccess", 3, "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, true, 1},
-  {"resolvedConflictDuringUpdate", 5, "dynamic", "", "192.168.1.65/26", "", false, true, 2},
-  {"unresolvedConflictAfterUpdate", 6, "dynamic", "", "", "", true, false, 1},
-  {"errorUpdate", 10, "dynamic", "", "", "", true, false, 1},
+  {"noIpsRequested", 0, "", "", "", "", false, 0},
+  {"noneIPv4", 0, "none", "", "none", "", false, 0},
+  {"noneIPv6", 0, "", "none", "", "none", false, 0},
+  {"noneDualStack", 0, "none", "none", "none", "none", false, 0},
+  {"dynamicErrorIPv4", 0, "dynamic", "", "", "", true, 0},
+  {"dynamicErrorIPv6", 0, "", "dynamic", "", "", true, 0},
+  {"dynamicErrorDualStack", 0, "dynamic", "dynamic", "", "", true, 0},
+  {"dynamicIPv4Success", 1, "dynamic", "", "192.168.1.65/26", "", false, 1},
+  {"dynamicIPv4Exhausted", 2, "dynamic", "", "", "", true, 0},
+  {"staticInvalidIPv4", 2, "hululululu", "", "", "", true, 0},
+  {"staticInvalidNoCidrIPv4", 2, "192.168.1.1", "", "", "", true, 0},
+  {"staticL2IPv4", 0, "192.168.1.1/26", "", "", "", true, 0},
+  {"staticNetmaskMismatchIPv4", 2, "192.168.1.1/32", "", "", "", true, 0},
+  {"staticAlreadyUsedIPv4", 2, "192.168.1.2/30", "", "", "", true, 0},
+  {"staticSuccessLastIPv4", 1, "192.168.1.126/26", "", "192.168.1.126/26", "", false, 1},
+  {"staticSuccessFirstIPv4", 11, "192.168.1.65/26", "", "192.168.1.65/26", "", false, 1},
+  {"staticFailAfterLastIPv4", 1, "192.168.1.127/26", "", "", "", true, 0},
+  {"staticFailBeforeFirstIPv4", 1, "192.168.1.64/26", "", "", "", true, 0},
+  {"dynamicIPv6Success", 3, "", "dynamic", "", "2a00:8a00:a000:1193", false, 0},
+  {"dynamicNotSupportedCidrSizeIPv6", 4, "", "dynamic", "", "", true, 0}, //basically anything smaller than /64. Restriction must be fixed some day!
+  {"staticL2IPv6", 2, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "", true, 0},
+  {"staticInvalidIPv6", 3, "", "2a00:8a00:a000:1193:hulu:lulu:lulu:lulu/64", "", "", true, 0},
+  {"staticNetmaskMismatchIPv6", 3, "", "2a00:8a00:a000:2193:f816:3eff:fe24:e348/64", "", "", true, 0},
+  {"staticIPv6Success", 3, "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, 0},
+  {"dynamicDualStackSuccess", 3, "dynamic", "dynamic", "192.168.1.65/26", "2a00:8a00:a000:1193", false, 1},
+  {"staticDualStackSuccess", 3, "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", "192.168.1.115/26", "2a00:8a00:a000:1193:f816:3eff:fe24:e348/64", false, 1},
+  {"resolvedConflictDuringUpdate", 5, "dynamic", "", "192.168.1.65/26", "", false, 2},
+  {"unresolvedConflictAfterUpdate", 6, "dynamic", "", "", "", true, 1},
+  {"errorUpdate", 10, "dynamic", "", "", "", true, 1},
 }
 
 var freeTcs = []struct {
@@ -109,15 +108,10 @@ func TestReserve(t *testing.T) {
       ips := utils.CreateExpectedAllocationsList(tc.expectedIp4,true,testNets[tc.netIndex].Spec.NetworkID)
       testArtifacts := utils.TestArtifacts{TestNets: testNets, ReservedIps: ips}
       netClientStub := stubs.NewClientSetStub(testArtifacts)
-      ip4, ip6, mac, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
+      ip4, ip6, err := ipam.Reserve(netClientStub, testNets[tc.netIndex], tc.requestedIp4, tc.requestedIp6)
       if (err != nil && !tc.isErrorExpected) || (err == nil && tc.isErrorExpected) {
         t.Errorf("Received error:%v does not match with expectation", err)
         return
-      }
-      if tc.isMacExpected {
-        if mac == "" {
-          t.Errorf("MAC address was expected to be returned, however it was not")
-        }
       }
       if ip4 != tc.expectedIp4 {
         t.Errorf("Allocated IP4 address:%s does not match with expected:%s", ip4, tc.expectedIp4)


### PR DESCRIPTION
Implementing the functional part of https://github.com/nokia/danm/issues/147, removing the restriction related to usable V6 prefixes.
Uses the new API attributes introduced in https://github.com/nokia/danm/pull/177.

As part of the change some generic aspects of IPAM are also streamlined:
- static IP addresses can now be provided in a simple IP format, no need for the prefix anymore (but prefixed format continues to work)
- MAC address is not needed as IPv6 allocation won't be based on random EUI64 anymore (but the DanmEp schema remains unchanged again for backward compatibility reasons)
- when an IPv6 address is requested from a network without Alloc6 and Pool6, ipam will automatically initialize these attributes. doing so apps will not be required to migrate their network objects to be able to use the new functionality, it should be a seamless experience (contrary to major enhancements in the past :) )