### PR TITLE
Do not delete danmep if its IP is not correctly released

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -249,9 +249,12 @@ func resetIp(alloc, cidr string, rip net.IP) string {
   return ba.Encode()
 }
 
-func GarbageCollectIps(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ip4, ip6 string) {
-  Free(danmClient, *netInfo, ip4)
-  Free(danmClient, *netInfo, ip6)
+func GarbageCollectIps(danmClient danmclientset.Interface, netInfo *danmtypes.DanmNet, ip4, ip6 string) error {
+  err := Free(danmClient, *netInfo, ip4)
+  if err != nil {
+    return err
+  }
+  return Free(danmClient, *netInfo, ip6)
 }
 
 // Ip2int converts an IP address stored according to the Golang net package to a native Golang big endian, 32-bit integer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
 bug
> cleanup
> design
> documentation
> failing-test
> feature

**What does this PR give to us**:
We need to keep the danmep there if the IP is not successfully freeed by the IPAM, so we still have the chance to release the IP by the cleaner later.

**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #167 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
