### PR TITLE
Adding V6 support to svcwatcher, plus fixing concurrent updates

### DIFF
--- a/cmd/svcwatcher/svcwatcher.go
+++ b/cmd/svcwatcher/svcwatcher.go
@@ -1,124 +1,113 @@
 package main
 
 import (
-	"context"
-	"flag"
-	"k8s.io/client-go/transport"
-	"log"
-	"time"
-	"os"
-	"fmt"
-	"github.com/golang/glog"
-	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/tools/clientcmd"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	corev1 "k8s.io/api/core/v1"
-	danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
-	danminformers "github.com/nokia/danm/crd/client/informers/externalversions"
-	"github.com/nokia/danm/pkg/svccontrol"
+  "context"
+  "flag"
+  "log"
+  "time"
+  "os"
+  "fmt"
+  "github.com/golang/glog"
+  kubeinformers "k8s.io/client-go/informers"
+  "k8s.io/client-go/tools/clientcmd"
+  "k8s.io/client-go/kubernetes"
+  "k8s.io/client-go/kubernetes/scheme"
+  "k8s.io/client-go/tools/leaderelection"
+  "k8s.io/client-go/tools/leaderelection/resourcelock"
+  "k8s.io/client-go/tools/record"
+  "k8s.io/client-go/transport"
+  utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+  v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+  corev1 "k8s.io/api/core/v1"
+  danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
+  danminformers "github.com/nokia/danm/crd/client/informers/externalversions"
+  "github.com/nokia/danm/pkg/svccontrol"
 )
 
 var (
-	kubeconfig, version, commitHash string
+  kubeconfig, version, commitHash string
 )
 
 func main() {
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	printVersion := flag.Bool("version", false, "prints Git version information of the binary to standard out")
-	flag.Parse()
-	if *printVersion {
-		log.Println("DANM binary was built from release: " + version)
-		log.Println("DANM binary was built from commit: " + commitHash)
-		return
-	}
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %s", err.Error())
-		return
-	}
-
-	// use a Go context so we can tell the leaderelection code when we
-	// want to step down
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// use a client that will stop allowing new requests once the context ends
-	cfg.Wrap(transport.ContextCanceller(ctx, fmt.Errorf("the leader is shutting down")))
-
-	kubeClient, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		glog.Fatalf("Error building kubernetes clientset: %s", err.Error())
-	}
-
-	danmClient, err := danmclientset.NewForConfig(cfg)
-	if err != nil {
-		glog.Fatalf("Error building example clientset: %s", err.Error())
-	}
-
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
-	danmInformerFactory := danminformers.NewSharedInformerFactory(danmClient, time.Second*30)
-
-	controller := svccontrol.NewController(kubeClient, danmClient,
-		kubeInformerFactory.Core().V1().Pods(),
-		kubeInformerFactory.Core().V1().Services(),
-		kubeInformerFactory.Core().V1().Endpoints(),
-		danmInformerFactory.Danm().V1().DanmEps())
-
-	run := func(ctx context.Context) {
-		go kubeInformerFactory.Start(ctx.Done())
-		go danmInformerFactory.Start(ctx.Done())
-
-		if err = controller.Run(10, ctx.Done()); err != nil {
-			glog.Fatalf("Error running controller: %s", err.Error())
-		}
-	}
-	
-	rl, err := resourcelock.New(resourcelock.EndpointsResourceLock,
-		"kube-system",
-		"danm-svc-controller",
-		kubeClient.CoreV1(),
-		kubeClient.CoordinationV1(),
-		resourcelock.ResourceLockConfig{
-			Identity:      GetHostname(),
-			EventRecorder: createRecorder(kubeClient, "danm-svc-controller"),
-		})
-	if err != nil {
-		glog.Fatalf("Error creating lock: %v", err)
-	}
-
-	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: 10 * time.Second,
-		RenewDeadline: 5 * time.Second,
-		RetryPeriod:   3 * time.Second,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: run,
-			OnStoppedLeading: func() {
-				utilruntime.HandleError(fmt.Errorf("Lost master"))
-			},
-		},
-	})
-
-	glog.Fatalln("Lost lease")
+  flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+  printVersion := flag.Bool("version", false, "prints Git version information of the binary to standard out")
+  flag.Parse()
+  if *printVersion {
+    log.Println("DANM binary was built from release: " + version)
+    log.Println("DANM binary was built from commit: " + commitHash)
+    return
+  }
+  cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+  if err != nil {
+    glog.Fatalf("Error building kubeconfig: %s", err.Error())
+    return
+  }
+  // use a Go context so we can tell the leaderelection code when we
+  // want to step down
+  ctx, cancel := context.WithCancel(context.Background())
+  defer cancel()
+  // use a client that will stop allowing new requests once the context ends
+  cfg.Wrap(transport.ContextCanceller(ctx, fmt.Errorf("the leader is shutting down")))
+  kubeClient, err := kubernetes.NewForConfig(cfg)
+  if err != nil {
+    glog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+  }
+  danmClient, err := danmclientset.NewForConfig(cfg)
+  if err != nil {
+    glog.Fatalf("Error building example clientset: %s", err.Error())
+  }
+  kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
+  danmInformerFactory := danminformers.NewSharedInformerFactory(danmClient, time.Second*30)
+  controller := svccontrol.NewController(kubeClient, danmClient,
+    kubeInformerFactory.Core().V1().Pods(),
+    kubeInformerFactory.Core().V1().Services(),
+    kubeInformerFactory.Core().V1().Endpoints(),
+    danmInformerFactory.Danm().V1().DanmEps())
+  run := func(ctx context.Context) {
+    go kubeInformerFactory.Start(ctx.Done())
+    go danmInformerFactory.Start(ctx.Done())
+    if err = controller.Run(10, ctx.Done()); err != nil {
+      glog.Fatalf("Error running controller: %s", err.Error())
+    }
+  }
+  rl, err := resourcelock.New(resourcelock.EndpointsResourceLock,
+    "kube-system",
+    "danm-svc-controller",
+    kubeClient.CoreV1(),
+    kubeClient.CoordinationV1(),
+    resourcelock.ResourceLockConfig{
+      Identity:      GetHostname(),
+      EventRecorder: createRecorder(kubeClient, "danm-svc-controller"),
+    })
+  if err != nil {
+    glog.Fatalf("Error creating lock: %v", err)
+  }
+  leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+    Lock:          rl,
+    LeaseDuration: 10 * time.Second,
+    RenewDeadline: 5 * time.Second,
+    RetryPeriod:   3 * time.Second,
+    Callbacks: leaderelection.LeaderCallbacks{
+      OnStartedLeading: run,
+      OnStoppedLeading: func() {
+        utilruntime.HandleError(fmt.Errorf("Lost master"))
+      },
+    },
+  })
+  glog.Fatalln("Lost lease")
 }
 
 func GetHostname() (string) {
-	ret, err := os.Hostname()
-	if err != nil {
-		glog.Fatalf("hostname %v", err)
-	}
-	return ret
+  ret, err := os.Hostname()
+  if err != nil {
+    glog.Fatalf("hostname %v", err)
+  }
+  return ret
 }
 
 func createRecorder(kubeClient *kubernetes.Clientset, comp string) record.EventRecorder {
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.Infof)
-	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("kube-system")})
-	return eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: comp})
+  eventBroadcaster := record.NewBroadcaster()
+  eventBroadcaster.StartLogging(glog.Infof)
+  eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("kube-system")})
+  return eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: comp})
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/intel/multus-cni v0.0.0-20200316130803-079c853eba60
 	github.com/intel/sriov-cni v2.1.0+incompatible
 	github.com/j-keck/arping v1.0.0
+	github.com/kr/pty v1.1.5 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/vishvananda/netlink v1.1.1-0.20200221165523-c79a4b7b4066
 	k8s.io/api v0.17.4

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -340,7 +340,9 @@ func createNic(syncher *syncher.Syncher, danmClient danmclientset.Interface, ifa
   isIpReservationNeeded := cnidel.IsDanmIpamNeededForDelegation(iface, netInfo) || netInfo.Spec.NetworkType == "ipvlan"
   ep, netInfo, err := danmep.CreateDanmEp(danmClient, DanmConfig.NamingScheme, isIpReservationNeeded, netInfo, iface, args)
   if err != nil {
-    danmep.DeleteDanmEp(danmClient, ep, netInfo)
+    if ep != nil {
+      danmep.DeleteDanmEp(danmClient, ep, netInfo)
+    }
     syncher.PushResult(ep.Spec.NetworkName, err, nil)
     return
   }

--- a/pkg/svccontrol/controller.go
+++ b/pkg/svccontrol/controller.go
@@ -23,11 +23,12 @@ import (
 	danminformers "github.com/nokia/danm/crd/client/informers/externalversions/danm/v1"
 	danmlisters "github.com/nokia/danm/crd/client/listers/danm/v1"
   "github.com/nokia/danm/pkg/datastructs"
+  "github.com/nokia/danm/pkg/ipam"
 )
 
 const (
-  MaxUpdateRetry = 5
-  RetryInterval  = 200
+  MaxUpdateRetry = 400
+  RetryInterval  = 25
 )
 
 type Controller struct {
@@ -73,21 +74,12 @@ func NewController(
 	glog.Info("Setting up event handlers")
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.addPod,
 		UpdateFunc: controller.updatePod,
-		DeleteFunc: controller.delPod,
 	})
 
 	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.addSvc,
 		UpdateFunc: controller.updateSvc,
-		DeleteFunc: controller.delSvc,
-	})
-
-	epsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.addEps,
-		UpdateFunc: controller.updateEps,
-		DeleteFunc: controller.delEps,
 	})
 
 	danmepInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -178,7 +170,8 @@ func (c *Controller) syncHandler(key string) error {
 func (c *Controller) EpCheckUpdate(ipAddr, ip6Addr string, eps *corev1.Endpoints, pod *corev1.Pod, early bool) error {
   wasIpv4AddressFound := isIpInEp(ipAddr,  eps)
   wasIpv6AddressFound := isIpInEp(ip6Addr, eps)
-  if (wasIpv4AddressFound || ipAddr == "") && (wasIpv6AddressFound || ip6Addr == "") {
+  if (wasIpv4AddressFound || (ipAddr  != "" && ipAddr  != ipam.NoneAllocType && ipAddr  != ipam.DynamicAllocType)) &&
+     (wasIpv6AddressFound || (ip6Addr != "" && ip6Addr != ipam.NoneAllocType && ip6Addr != ipam.DynamicAllocType)) {
     return nil
   }
   host := getPodHost(pod)
@@ -202,20 +195,7 @@ func (c *Controller) UpdateEndpoints(eps *corev1.Endpoints) error {
      len(eps.Subsets[0].NotReadyAddresses) == 0 {
 		eps.Subsets = nil
 	}
-  var updateCounter int
-  var err error
-  for {
-    if updateCounter >= MaxUpdateRetry {
-      break
-    }
-	  _, err := c.kubeclient.CoreV1().Endpoints(eps.Namespace).Update(eps)
-    if err == nil {
-      break
-    } else if !strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg){
-      updateCounter++
-    }
-    time.Sleep(RetryInterval * time.Millisecond)
-  }
+  _, err := c.kubeclient.CoreV1().Endpoints(eps.Namespace).Update(eps)
   return err
 }
 
@@ -230,13 +210,15 @@ func (c *Controller) UpdateEndpointsList(epList []*corev1.Endpoints) error {
   return nil
 }
 
-func (c *Controller) CreateModifyEndpoints(svc *corev1.Service, doesEpAlreadyExist bool, des []*danmv1.DanmEp) {
-	epNew := c.MakeNewEps(svc, des)
+func (c *Controller) CreateModifyEndpoints(svc *corev1.Service, doesEpAlreadyExist bool, des []*danmv1.DanmEp) error {
+  var err error
+	epNew := c.MakeNewEps(svc, des)  
   if doesEpAlreadyExist {
-		c.kubeclient.CoreV1().Endpoints(svc.Namespace).Update(&epNew)
+		_, err = c.kubeclient.CoreV1().Endpoints(svc.Namespace).Update(&epNew)
 	} else {
-		c.kubeclient.CoreV1().Endpoints(svc.Namespace).Create(&epNew)
+		_, err = c.kubeclient.CoreV1().Endpoints(svc.Namespace).Create(&epNew)
 	}
+  return err
 }
 
 func (c* Controller) UpdatePodRvInEps(epsList []*corev1.Endpoints, pod *corev1.Pod) ([]*corev1.Endpoints) {
@@ -400,23 +382,39 @@ func (c *Controller) addDanmep(obj interface{}) {
 				glog.Errorf("addDanmEp: get pod %s", err)
 				continue
 			}
-			eps, err := c.epsLister.Endpoints(svc.Namespace).Get(svc.Name)
-			if err != nil && !errors.IsNotFound(err) {
-				glog.Errorf("addDanmEp: get ep %s", err)
-				continue
-			}
-			if eps != nil && eps.Subsets != nil {
-				early := (svc.Annotations[TolerateUnreadyEps] == "true")
-				err := c.EpCheckUpdate(ipAddr, ip6Addr, eps.DeepCopy(), pod, early)
+      for i := 0; i < MaxUpdateRetry; i++ {
+			  eps, err := c.epsLister.Endpoints(svc.Namespace).Get(svc.Name)
+			  if err != nil && !errors.IsNotFound(err) {
+				  glog.Errorf("addDanmEp: get ep %s", err)
+				  break
+			  }
+			  if eps != nil && eps.Subsets != nil {
+				  early := (svc.Annotations[TolerateUnreadyEps] == "true")
+				  err := c.EpCheckUpdate(ipAddr, ip6Addr, eps.DeepCopy(), pod, early)
           if err != nil {
-            glog.Errorf("Add danmep conflict: %s %s %+v", ipAddr, ip6Addr, eps)
+            if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
+              time.Sleep(RetryInterval * time.Millisecond)
+              continue
+            } else {
+              glog.Errorf("Endpoint update for new DanmEp:%s failed with error:%s", de.ObjectMeta.Name, err)
+            }
           }
-				continue
+        } else {
+		    	desList := []*danmv1.DanmEp{de}
+			    err = c.CreateModifyEndpoints(svc, true, desList)
+          if err != nil {
+            if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
+              time.Sleep(RetryInterval * time.Millisecond)
+              continue
+            } else {
+              glog.Errorf("Endpoint creation for new DanmEp:%s failed with error:%s", de.ObjectMeta.Name, err)
+            }
+          }
+        }
+				break
 			}
-			desList := []*danmv1.DanmEp{de}
-			c.CreateModifyEndpoints(svc, true, desList)
-		}
-	}
+	  }
+  }
 }
 
 func (c *Controller) updateDanmep(old, new interface{}) {
@@ -437,43 +435,51 @@ func (c *Controller) delDanmep(obj interface{}) {
 	deNs := de.Namespace
 	var epList []*corev1.Endpoints
 	sel := labels.Everything()
-	epsList, err := c.epsLister.List(sel)
-	if err != nil {
-		glog.Errorf("delDanmep: get epslist: %s", err)
-		return
-	}
-	for _, ep := range epsList {
-		if ep.Subsets == nil {
-			continue
-		}
-		epNew := ep.DeepCopy()
-		annotations := epNew.GetAnnotations()
-		selectorMap, svcNets, err := GetDanmSvcAnnotations(annotations)
-		if err != nil {
-			glog.Errorf("delDanmEp: selector %s", err)
-			return
-		}
-		if len(selectorMap) == 0 || !isDepSelectedBySvc(de, svcNets) || epNew.Namespace != deNs {
-			continue
-		}
-		deMap := de.GetLabels()
-		deFit := IsContain(deMap, selectorMap)
-		if !deFit {
-			continue
-		}
-		for index, address := range ep.Subsets[0].Addresses {
-      epNew.Subsets[0].Addresses = deleteFromEpAddressList(ipAddr, ip6Addr, index, address, epNew.Subsets[0].Addresses)
-		}
-		for index, address := range ep.Subsets[0].NotReadyAddresses {
-      epNew.Subsets[0].NotReadyAddresses = deleteFromEpAddressList(ipAddr, ip6Addr, index, address, epNew.Subsets[0].NotReadyAddresses)
-		}
-    epList = append(epList, epNew)
-	}
-	if len(epList) > 0 {
-		err = c.UpdateEndpointsList(epList)
-    if err != nil {
-      glog.Errorf("delete DanmEp even could not be processed for V4 address: %s and V6 address: %s because of error:%v", ipAddr, ip6Addr, err)
+  for i := 0; i < MaxUpdateRetry; i++ {
+	  epsList, err := c.epsLister.List(sel)
+	  if err != nil {
+		  glog.Errorf("delDanmep: get epslist: %s", err)
+		  return
+	  }
+	  for _, ep := range epsList {
+		  if ep.Subsets == nil {
+			  continue
+		  }
+		  epNew := ep.DeepCopy()
+		  annotations := epNew.GetAnnotations()
+		  selectorMap, svcNets, err := GetDanmSvcAnnotations(annotations)
+		  if err != nil {
+			  glog.Errorf("delDanmEp: selector %s", err)
+			  return
+		  }
+		  if len(selectorMap) == 0 || !isDepSelectedBySvc(de, svcNets) || epNew.Namespace != deNs {
+			  continue
+		  }
+		  deMap := de.GetLabels()
+		  deFit := IsContain(deMap, selectorMap)
+		  if !deFit {
+			  continue
+		  }
+		  for index, address := range ep.Subsets[0].Addresses {
+        epNew.Subsets[0].Addresses = deleteFromEpAddressList(ipAddr, ip6Addr, index, address, epNew.Subsets[0].Addresses)
+		  }
+		  for index, address := range ep.Subsets[0].NotReadyAddresses {
+        epNew.Subsets[0].NotReadyAddresses = deleteFromEpAddressList(ipAddr, ip6Addr, index, address, epNew.Subsets[0].NotReadyAddresses)
+		  }
+      epList = append(epList, epNew)
+	  }
+	  if len(epList) > 0 {
+		  err = c.UpdateEndpointsList(epList)
+      if err != nil {
+        if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
+          time.Sleep(RetryInterval * time.Millisecond)
+          continue
+        } else {
+          glog.Errorf("delete DanmEp event could not be processed for V4 address: %s and V6 address: %s because of error:%v", ipAddr, ip6Addr, err)
+        }
+      }
     }
+    break
 	}
 }
 
@@ -482,44 +488,63 @@ func (c *Controller) delDanmep(obj interface{}) {
 //  Pod change handlers  //
 //                       //
 ///////////////////////////
-func (c *Controller) addPod(obj interface{}) {
-	// pod adding is handled by cni where danmep is involved, no action is needed
-	if !c.podSynced() || !c.serviceSynced() || !c.epsSynced() || !c.danmepSynced() {
-		return
-	}
-	glog.V(5).Infof("addPod is called: %s %s", obj.(*corev1.Pod).GetName(), obj.(*corev1.Pod).GetNamespace())
-}
-
 func (c *Controller) updatePod(old, new interface{}) {
 	glog.V(5).Infof("updatePod is called: %s %s", new.(*corev1.Pod).GetName(), new.(*corev1.Pod).GetNamespace())
 	oldPod := old.(*corev1.Pod)
 	newPod := new.(*corev1.Pod)
-	if oldPod.ResourceVersion == newPod.ResourceVersion {
+	if oldPod.ResourceVersion == newPod.ResourceVersion || newPod.ObjectMeta.DeletionTimestamp != nil {
 		return
 	}
+  
 	labelChange := PodLabelChanged(oldPod, newPod)
 	oldReady := PodReady(oldPod)
 	newReady := PodReady(newPod)
 	sel := labels.Everything()
-	epsList, err := c.epsLister.List(sel)
-	if err != nil {
-		glog.Errorf("updatePod: get eps %s", err)
-		return
-	}
 	if oldReady == newReady && !labelChange {
-		// nothing is changed just resource version. endpoints targetref need to be updated
-		epList := c.UpdatePodRvInEps(epsList, newPod)
-		if len(epList) > 0 {
-			c.UpdateEndpointsList(epList)
+		// nothing is changed just resource version. endpoints targetref need to be updated		
+    for i := 0; i < MaxUpdateRetry; i++ {
+      epsList, err := c.epsLister.List(sel)
+	    if err != nil {
+		    glog.Errorf("updatePod: get eps %s", err)
+		    return
+	    }
+      epList := c.UpdatePodRvInEps(epsList, newPod)
+		  if len(epList) > 0 {
+			  err = c.UpdateEndpointsList(epList)
+        if err != nil {
+          if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
+            time.Sleep(RetryInterval * time.Millisecond)
+            continue
+          } else {
+            glog.Errorf("Endpoint update for changed Pod:%s failed with error:%s", newPod.ObjectMeta.Name, err)
+          }
+        }
+      }
+      break
 		}
 		return
 	}
 	// first we need to reflect status change
 	if oldReady != newReady {
-		// status change
-		epList := c.UpdatePodStatusInEps(epsList, newPod, oldReady, newReady)
-		if len(epList) > 0 {
-			c.UpdateEndpointsList(epList)
+    for i := 0; i < MaxUpdateRetry; i++ {
+      epsList, err := c.epsLister.List(sel)
+	    if err != nil {
+		    glog.Errorf("updatePod: get eps %s", err)
+		    return
+	    }
+		  epList := c.UpdatePodStatusInEps(epsList, newPod, oldReady, newReady)
+		  if len(epList) > 0 {
+			  err = c.UpdateEndpointsList(epList)
+        if err != nil {
+          if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
+            time.Sleep(RetryInterval * time.Millisecond)
+            continue
+          } else {
+            glog.Errorf("Endpoint update for changed Pod:%s failed with error:%s", newPod.ObjectMeta.Name, err)
+          }
+        }
+      }
+      break
 		}
 	}
 	// label change has lower priority
@@ -537,15 +562,13 @@ func (c *Controller) updatePod(old, new interface{}) {
 			if deNew.Spec.Pod == podName && deNew.Namespace == podNs {
 				deLabels := newPod.Labels
 				deNew.SetLabels(deLabels)
-				c.danmclient.DanmV1().DanmEps(deNew.Namespace).Update(deNew)
-			}
+				_, err = c.danmclient.DanmV1().DanmEps(deNew.Namespace).Update(deNew)
+        if err != nil {
+          glog.Errorf("DanmEp:%s label update for changed Pod:%s failed with error:%s", deNew.ObjectMeta.Name, newPod.ObjectMeta.Name, err)
+        }
+      }
 		}
 	}
-}
-
-func (c *Controller) delPod(obj interface{}) {
-	// pod deletion is handled by cni where danmep is involved, no action is needed
-	glog.V(5).Infof("delPod is called: %s %s", obj.(*corev1.Pod).GetName(), obj.(*corev1.Pod).GetNamespace())
 }
 
 ///////////////////////////
@@ -568,20 +591,31 @@ func (c *Controller) addSvc(obj interface{}) {
 		return
 	}
 	if len(selectorMap) > 0 && len(svcNets) > 0 {
-		sel := labels.Everything()
-		d, err := c.danmepLister.List(sel)
-		if err != nil {
-			glog.Errorf("addSvc: get danmep %s", err)
-			return
-		}
-		deList := SelectDesMatchLabels(d, selectorMap, svcNets, svcNs)
-		e, err := c.epsLister.List(sel)
-		if err != nil {
-			glog.Errorf("addSvc: get eps %s", err)
-			return
-		}
-		epFound := FindEpsForSvc(e, svcName, svcNs)
-		c.CreateModifyEndpoints(svc, epFound, deList)
+    for i := 0; i < MaxUpdateRetry; i++ {
+		  sel := labels.Everything()
+		  d, err := c.danmepLister.List(sel)
+		  if err != nil {
+			  glog.Errorf("addSvc: get danmep %s", err)
+			  return
+		  }
+		  deList := SelectDesMatchLabels(d, selectorMap, svcNets, svcNs)
+		  e, err := c.epsLister.List(sel)
+		  if err != nil {
+			  glog.Errorf("addSvc: get eps %s", err)
+			  return
+		  }
+		  epFound := FindEpsForSvc(e, svcName, svcNs)
+		  err = c.CreateModifyEndpoints(svc, epFound, deList)
+      if err != nil {
+        if strings.Contains(err.Error(), datastructs.OptimisticLockErrorMsg) {
+          time.Sleep(RetryInterval * time.Millisecond)
+          continue
+        } else {
+          glog.Errorf("Endpoint creation for new Service:%s failed with error:%s", svcName, err)
+        }
+      }
+      break
+    }
 	}
 }
 
@@ -593,35 +627,6 @@ func (c *Controller) updateSvc(old, new interface{}) {
 		return
 	}
 	c.addSvc(new)
-}
-
-func (c *Controller) delSvc(obj interface{}) {
-	glog.V(5).Infof("delSvc is called: %s %s", obj.(*corev1.Service).GetName(), obj.(*corev1.Service).GetNamespace())
-}
-
-///////////////////////////
-//                       //
-//  Eps change handlers  //
-//                       //
-///////////////////////////
-func (c *Controller) addEps(obj interface{}) {
-	if !c.podSynced() || !c.serviceSynced() || !c.epsSynced() || !c.danmepSynced() {
-		return
-	}
-	glog.V(5).Infof("addEps is called: %s %s", obj.(*corev1.Endpoints).GetName(), obj.(*corev1.Endpoints).GetNamespace())
-}
-
-func (c *Controller) updateEps(old, new interface{}) {
-	glog.V(5).Infof("updateEps is called: %s %s", new.(*corev1.Endpoints).GetName(), new.(*corev1.Endpoints).GetNamespace())
-	oldEps := old.(*corev1.Endpoints)
-	newEps := new.(*corev1.Endpoints)
-	if oldEps.ResourceVersion == newEps.ResourceVersion {
-		return
-	}
-}
-
-func (c *Controller) delEps(obj interface{}) {
-	glog.V(5).Infof("delEps is called: %s %s", obj.(*corev1.Endpoints).GetName(), obj.(*corev1.Endpoints).GetNamespace())
 }
 
 func isIpInEp(ip string, eps *corev1.Endpoints) bool {
@@ -636,10 +641,12 @@ func isIpInEp(ip string, eps *corev1.Endpoints) bool {
 }
 
 func createChangedEpAddressList(v4Address, v6Address, host string, eps *corev1.Endpoints, targetRef *corev1.ObjectReference, epAddrs []corev1.EndpointAddress) []corev1.EndpointAddress {
-  if eps == nil || (v4Address != "" && !isIpInEp(v4Address, eps)) {
+  if (v4Address != "" && v4Address != ipam.NoneAllocType &&  v4Address != ipam.DynamicAllocType) &&
+     (eps == nil || !isIpInEp(v4Address, eps)) {
     epAddrs = append(epAddrs, corev1.EndpointAddress{IP: v4Address, Hostname: host, TargetRef: targetRef})
   }
-  if eps == nil || (v6Address != "" && !isIpInEp(v6Address, eps)) {
+  if (v6Address != "" && v6Address != ipam.NoneAllocType &&  v6Address != ipam.DynamicAllocType) &&
+     (eps == nil || !isIpInEp(v6Address, eps)) {
     epAddrs = append(epAddrs, corev1.EndpointAddress{IP: v6Address, Hostname: host, TargetRef: targetRef})
   }
   return epAddrs


### PR DESCRIPTION
DANM svcwatcher managed EndPoints now support IPv6 addresses as well!

also correcting https://github.com/nokia/danm/issues/185
Correction is not the elegant one, but should work with the current architectural constraints.
We will infinitely re-try EndPoint update in case of conflict, but only retry for 1 sec in case of temporary network outages etc.

