### PR TITLE
Increase resiliency of critical execution paths against temporary, or permanent network outages

### DIFF
--- a/crd/apis/danm/v1/types.go
+++ b/crd/apis/danm/v1/types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
   meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/apimachinery/pkg/types"
 )
 
 // +genclient
@@ -85,6 +86,7 @@ type DanmEpSpec struct {
   Iface       DanmEpIface `json:"Interface"`
   Host        string      `json:"Host,omitempty"`
   Pod         string      `json:"Pod"`
+  PodUID      types.UID   `json:"PodUID,omitempty"`
   CID         string      `json:"CID,omitempty"`
   Netns       string      `json:"netns,omitempty"`
   ApiType     string      `json:"apiType"`

--- a/pkg/cnidel/cniconfs.go
+++ b/pkg/cnidel/cniconfs.go
@@ -10,27 +10,6 @@ import (
   sriov_utils "github.com/intel/sriov-cni/pkg/utils"
 )
 
-var (
-  SupportedNativeCnis = map[string]*cniBackendConfig {
-    "sriov": &cniBackendConfig {
-      CniBackend: datastructs.CniBackend {
-        CNIVersion: "0.3.1",
-      },
-      readConfig: cniConfigReader(getSriovCniConfig),
-      ipamNeeded: true,
-      deviceNeeded: true,
-    },
-    "macvlan": &cniBackendConfig {
-      CniBackend: datastructs.CniBackend {
-        CNIVersion: "0.3.1",
-      },
-      readConfig: cniConfigReader(getMacvlanCniConfig),
-      ipamNeeded: true,
-      deviceNeeded: false,
-    },
-  }
-)
-
 //This function creates CNI configuration for all static-level backends
 //The CNI binary matching with NetowrkType is invoked with the CNI config file matching with NetworkID parameter
 func readCniConfigFile(cniconfDir string, netInfo *danmtypes.DanmNet, ipamOptions datastructs.IpamConfig) ([]byte, error) {

--- a/pkg/cnidel/cnidel.go
+++ b/pkg/cnidel/cnidel.go
@@ -14,7 +14,6 @@ import (
   "github.com/nokia/danm/pkg/datastructs"
   "github.com/nokia/danm/pkg/ipam"
   danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
-  danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
 )
 
 const (
@@ -41,7 +40,7 @@ func IsDelegationRequired(netInfo *danmtypes.DanmNet) bool {
 // DelegateInterfaceSetup delegates K8s Pod network interface setup task to the input 3rd party CNI plugin
 // Returns the CNI compatible result object, or an error if interface creation was unsuccessful, or if the 3rd party CNI config could not be loaded
 //TODO: I hate myself for the bool input parameter, but that's what we are going with for the time being. Could be this information cleverly defaulted from existing DanmEp spec in all cases?
-func DelegateInterfaceSetup(netConf *datastructs.NetConf, danmClient danmclientset.Interface, wasIpReservedByDanmIpam bool, netInfo *danmtypes.DanmNet, ep *danmtypes.DanmEp) (*current.Result,error) {
+func DelegateInterfaceSetup(netConf *datastructs.NetConf, wasIpReservedByDanmIpam bool, netInfo *danmtypes.DanmNet, ep *danmtypes.DanmEp) (*current.Result,error) {
   var (
     err error
     ipamOptions datastructs.IpamConfig

--- a/pkg/cnidel/types.go
+++ b/pkg/cnidel/types.go
@@ -3,18 +3,25 @@ package cnidel
 import (
   "github.com/containernetworking/cni/pkg/types"
   sriov_types "github.com/intel/sriov-cni/pkg/types"
-  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
   "github.com/nokia/danm/pkg/datastructs"
 )
 
-type cniConfigReader func(netInfo *danmtypes.DanmNet, ipam datastructs.IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error)
-
-type cniBackendConfig struct {
-  datastructs.CniBackend
-  readConfig cniConfigReader
-  ipamNeeded bool
-  deviceNeeded bool
-}
+var(
+  SupportedNativeCnis = map[string]*datastructs.CniBackendConfig {
+    "sriov": &datastructs.CniBackendConfig {
+      CNIVersion: "0.3.1",
+      ReadConfig: datastructs.CniConfigReader(getSriovCniConfig),
+      IpamNeeded: true,
+      DeviceNeeded: true,
+    },
+    "macvlan": &datastructs.CniBackendConfig {
+      CNIVersion: "0.3.1",
+      ReadConfig: datastructs.CniConfigReader(getMacvlanCniConfig),
+      IpamNeeded: true,
+      DeviceNeeded: false,
+    },
+  }
+)
 
 // sriovNet represent the configuration of sriov cni v1.0.0
 type SriovNet struct {

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -208,7 +208,7 @@ func addPolicyRoute(rtable int, cidr string, proutes map[string]string) error {
   return nil
 }
 
-func deleteContainerIface(ep danmtypes.DanmEp) error {
+func deleteContainerIface(ep *danmtypes.DanmEp) error {
   runtime.LockOSThread()
   defer runtime.UnlockOSThread()
   origns, err := ns.GetCurrentNS()
@@ -254,7 +254,7 @@ func determineIfName(dnet *danmtypes.DanmNet) string {
   return device
 }
 
-func deleteEp(ep danmtypes.DanmEp) error {
+func deleteEp(ep *danmtypes.DanmEp) error {
   if ns.IsNSorErr(ep.Spec.Netns) != nil {
     return errors.New("Cannot find netns")
   }

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -14,7 +14,7 @@ import (
   "github.com/j-keck/arping"
 )
 
-func createIpvlanInterface(dnet *danmtypes.DanmNet, ep danmtypes.DanmEp) error {
+func createIpvlanInterface(dnet *danmtypes.DanmNet, ep *danmtypes.DanmEp) error {
   host, err := os.Hostname()
   if err != nil {
     return errors.New("cannot get hostname because:" + err.Error())
@@ -30,7 +30,7 @@ func createIpvlanInterface(dnet *danmtypes.DanmNet, ep danmtypes.DanmEp) error {
   return createContainerIface(ep, dnet, device)
 }
 
-func createContainerIface(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, device string) error {
+func createContainerIface(ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet, device string) error {
   runtime.LockOSThread()
   defer runtime.UnlockOSThread()
   origns, err := ns.GetCurrentNS()
@@ -97,7 +97,7 @@ func createContainerIface(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet, device s
   return nil
 }
 
-func configureLink(iface netlink.Link, ep danmtypes.DanmEp) error {
+func configureLink(iface netlink.Link, ep *danmtypes.DanmEp) error {
   var err error
   if ep.Spec.Iface.Address != "" && ep.Spec.Iface.Address != ipam.NoneAllocType {
     err = addIpToLink(ep.Spec.Iface.Address, iface)
@@ -135,7 +135,7 @@ func addIpToLink(ip string, iface netlink.Link) error {
   return nil
 }
 
-func addIpRoutes(ep danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
+func addIpRoutes(ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
   defaultRoutingTable := 0
   err := addRoutes(dnet.Spec.Options.Routes, defaultRoutingTable)
   if err != nil {
@@ -261,7 +261,7 @@ func deleteEp(ep danmtypes.DanmEp) error {
   return deleteContainerIface(ep)
 }
 
-func createDummyInterface(ep danmtypes.DanmEp) error {
+func createDummyInterface(ep *danmtypes.DanmEp) error {
   dummy := &netlink.Dummy {
     LinkAttrs: netlink.LinkAttrs {
       Name: ep.Spec.Iface.Name,

--- a/pkg/datastructs/datastructs.go
+++ b/pkg/datastructs/datastructs.go
@@ -3,6 +3,8 @@ package datastructs
 import (
   "github.com/containernetworking/cni/pkg/types"
   "github.com/containernetworking/cni/pkg/version"
+  danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+  core_v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -15,6 +17,7 @@ const (
 
 var (
   SupportedCniVersions = version.PluginSupports("0.3.1")
+  LegacyNamingScheme = "legacy"
 )
 
 type NetConf struct {
@@ -24,8 +27,13 @@ type NetConf struct {
   NamingScheme        string `json:"namingScheme"`
 }
 
-type CniBackend struct {
+type CniConfigReader func(netInfo *danmtypes.DanmNet, ipam IpamConfig, ep *danmtypes.DanmEp, cniVersion string) ([]byte, error)
+
+type CniBackendConfig struct {
   CNIVersion string
+  ReadConfig CniConfigReader
+  IpamNeeded bool
+  DeviceNeeded bool
 }
 
 // Interface represents a request coming from the Pod to connect it to one DanmNet during CNI_ADD operation
@@ -53,4 +61,15 @@ type IpamConfig struct {
 type IpamIp struct {
   IpCidr    string      `json:"ipcidr"`
   Version   int         `json:"version"`
+}
+
+type CniArgs struct {
+  Namespace string
+  Netns string
+  PodName string
+  ContainerId string
+  StdIn []byte
+  Interfaces []Interface
+  Pod *core_v1.Pod
+  DefaultNetwork *danmtypes.DanmNet
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -62,7 +62,7 @@ func Free(danmClient danmclientset.Interface, netInfo danmtypes.DanmNet, rip str
   tempNet := netInfo
   origSpec:= netInfo.Spec
   for {
-    if ip.To4() != nil { 
+    if ip.To4() != nil {
       tempNet.Spec.Options.Alloc = resetIp(tempNet.Spec.Options.Alloc, tempNet.Spec.Options.Cidr, ip)
     } else {
       tempNet.Spec.Options.Alloc6 = resetIp(tempNet.Spec.Options.Alloc6, tempNet.Spec.Options.Pool6.Cidr, ip)
@@ -129,7 +129,7 @@ func allocateAddress(pool *danmtypes.IpPool, alloc, reqType, cidr string) (strin
     var lastIpIndex uint32
     if pool.LastIp != "" {
       lastIp := net.ParseIP(pool.LastIp)
-      lastIpIndex = GetIndexOfIp(lastIp, subnet)      
+      lastIpIndex = GetIndexOfIp(lastIp, subnet)
     }
     if lastIpIndex >= end || lastIpIndex == 0 {
       lastIpIndex = begin
@@ -217,7 +217,7 @@ func getIpFromIndex(index uint32, subnet *net.IPNet) string {
   } else {
     firstIpAsBigInt := Ip62int(subnet.IP)
     indexAsBigInt   := new(big.Int).SetUint64(uint64(index))
-    ip = Int2ip6(firstIpAsBigInt.Add(firstIpAsBigInt, indexAsBigInt))  
+    ip = Int2ip6(firstIpAsBigInt.Add(firstIpAsBigInt, indexAsBigInt))
   }
   return ip.String() + "/" + strconv.Itoa(prefix)
 }
@@ -338,7 +338,7 @@ func InitV6PoolCidr(netInfo *danmtypes.DanmNet) {
   baseCidrStart := netCidr.IP
   pool6CidrPrefix := GetMaxUsableV6Prefix(netInfo)
   //If the subnet of the whole network is smaller than the maximum remaining capacity, use only that amount
-  net6Prefix,_ := netCidr.Mask.Size() 
+  net6Prefix,_ := netCidr.Mask.Size()
   if pool6CidrPrefix < net6Prefix {
     pool6CidrPrefix = net6Prefix
   }

--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -367,7 +367,7 @@ func createNic(syncher *syncher.Syncher, danmClient danmclientset.Interface, ifa
 func createDelegatedInterface(danmClient danmclientset.Interface, wasIpReservedByDanmIpam bool, ep *danmtypes.DanmEp, netInfo *danmtypes.DanmNet, args *datastructs.CniArgs) (*current.Result,error) {
   origV4Address := ep.Spec.Iface.Address
   origV6Address := ep.Spec.Iface.AddressIPv6
-  delegatedResult,err := cnidel.DelegateInterfaceSetup(DanmConfig, danmClient, wasIpReservedByDanmIpam, netInfo, ep)
+  delegatedResult,err := cnidel.DelegateInterfaceSetup(DanmConfig, wasIpReservedByDanmIpam, netInfo, ep)
   if err != nil {
     //TODO: is this -basically only host-ipam related- stuff really needed, or is just legacy residue?
     cnidel.FreeDelegatedIps(netInfo, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)

--- a/pkg/netcontrol/netcontrol.go
+++ b/pkg/netcontrol/netcontrol.go
@@ -399,7 +399,7 @@ func GetNetworkFromInterface(danmClient danmclientset.Interface, iface datastruc
   return nil, errors.New("requested network:" + netName + " of type:" + netType + " in namespace:" + nameSpace + " does not exist")
 }
 
-func GetNetworkFromEp(danmClient danmclientset.Interface, ep danmtypes.DanmEp) (*danmtypes.DanmNet,error) {
+func GetNetworkFromEp(danmClient danmclientset.Interface, ep *danmtypes.DanmEp) (*danmtypes.DanmNet,error) {
   dummyIface := datastructs.Interface{}
   if ep.Spec.ApiType == DanmNetKind || ep.Spec.ApiType == "" {dummyIface.Network = ep.Spec.NetworkName}
   if ep.Spec.ApiType == TenantNetworkKind  {dummyIface.TenantNetwork = ep.Spec.NetworkName}


### PR DESCRIPTION
Umbrella ticket to fully solve https://github.com/nokia/danm/issues/166 and https://github.com/nokia/danm/issues/165, and partially https://github.com/nokia/danm/issues/167.

In the new structure DanmEps will never be cleaned when its related IPs could not be freed in the network for any reason. In these scenarios it will become either user, or Cleaner's responsibility to handle the dangling resources.