### PR TITLE
Use DANM CNI ServiceAccount rather than user account

### DIFF
--- a/integration/cni_config/00-danm.conf
+++ b/integration/cni_config/00-danm.conf
@@ -5,7 +5,7 @@
   "type": "danm",
   "type_comment": "Mandatory parameter according to CNI spec, MUST be set to danm",
   "kubeconfig": "/etc/kubernetes/kubeconfig/danmc.yml",
-  "kubeconfig_comment": "Mandatory parameter, must point to a valid kubeconfig file containing the necessary RBAC setting for DANM's user",
+  "kubeconfig_comment": "Mandatory parameter, must point to a valid kubeconfig file containing the necessary RBAC setting for DANM's service account",
   "cniDir": "/etc/cni/net.d",
   "cniDir_comment": "Optional parameter, if defined CNI config files for static delegates are searched here. Default value is /etc/cni/net.d",
   "namingScheme": "awesome",

--- a/integration/cni_config/danm_rbac.yaml
+++ b/integration/cni_config/danm_rbac.yaml
@@ -25,6 +25,6 @@ roleRef:
   kind: ClusterRole
   name: caas:danm
 subjects:
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    namespace: kube-system
     name: danm

--- a/integration/cni_config/example_kubeconfig.yaml
+++ b/integration/cni_config/example_kubeconfig.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: <BASE64_ENCODED_CA_CERT>
-    server: https://10.254.0.1:443
-  name: kubernetes
+    certificate-authority-data: ${CLUSTER_CA_CERTIFICATE}
+    server: ${CLUSTER_SERVER}
+  name: ${CLUSTER_NAME}
 contexts:
 - context:
-    cluster: kubernetes
+    cluster: ${CLUSTER_NAME}
     user: danm
   name: default
 current-context: default
@@ -15,5 +15,4 @@ preferences: {}
 users:
 - name: danm
   user:
-    client-certificate-data: <BASE64_ENCODED_CLIENT_CERT>
-    client-key-data: <BASE64_ENCODED_CLIENT_KEY>
+    token: ${SERVICEACCOUNT_TOKEN}


### PR DESCRIPTION
Configure the DANM CNI kubeconfig file with a ServiceAccount rather
than a (human) user account.

Also, update deployment-guide with steps how to create such user
account and extract the token, and update the example kubeconfig
file such that it references variable names used in the
deployment-guide. (This should effectively allow readers to create
the kubeconfig file simply by running "envsubst" if they followed
the deployment guide exactly.)

**What type of PR is this?**
documentation

**What does this PR give to us**:
Somewhat more user-friendly documentation (explicit steps to create a DANM account, rather than
an example kubeconfig file that refers to an exiting user key/cert with little guidance on how to
create that), and a configuration that's somewhat more inline with Kubernetes recommendations,
as Kubernetes documentation generally suggests using a ServiceAccount rather than a user for
non-human interaction.

**Does this PR introduce a user-facing change?**:
NONE