### PR TITLE
Update DaemonSet API to v1

### DIFF
--- a/integration/manifests/netwatcher/netwatcher_ds.yaml
+++ b/integration/manifests/netwatcher/netwatcher_ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: netwatcher

--- a/integration/manifests/svcwatcher/svcwatcher_ds.yaml
+++ b/integration/manifests/svcwatcher/svcwatcher_ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: svcwatcher


### PR DESCRIPTION
As per Kubernetes 1.16, DaemonSet API v1betaX is deprecated and using v1 is recommended.
https://v1-16.docs.kubernetes.io/docs/setup/release/notes/#deprecations-and-removals.

As v1.17 is now listed as a supported version in the deployment guide, it seems to make sense
to update the daemonset to API version 1.

**What type of PR is this?**
bugfix

**What does this PR give to us**:
A daemonset resource configuration that loads into K8s v1.17 without errors :-)

**Does this PR introduce a user-facing change?**:
NONE.
API v1 existed since Kubernetes v1.9, and older versions are already declared 'not supported' in the deployment guide - so for users who are running a supported version, there should be no change.