### PR TITLE
Grant Events Create permission to svcwatcher RBAC

### DIFF
--- a/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
+++ b/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
@@ -34,6 +34,14 @@ rules:
   - watch
   - get
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - get
+- apiGroups:
   - "danm.k8s.io"
   resources:
   - danmeps


### PR DESCRIPTION
Seeing following error in svcwatcher log,
'User "system:serviceaccount:kube-system:svcwatcher" cannot
create resource "events" in API group "" in the namespace "kube-system"'.

Adding this API to svcwatcher RBAC.


**What type of PR is this?**
bug

**What does this PR give to us**:

**Does this PR introduce a user-facing change?**:
NONE