### PR TITLE
Fix possible nil derefernce in metacni error handling

### DIFF
--- a/pkg/metacni/metacni.go
+++ b/pkg/metacni/metacni.go
@@ -343,7 +343,7 @@ func createNic(syncher *syncher.Syncher, danmClient danmclientset.Interface, ifa
     if ep != nil {
       danmep.DeleteDanmEp(danmClient, ep, netInfo)
     }
-    syncher.PushResult(ep.Spec.NetworkName, err, nil)
+    syncher.PushResult(netInfo.ObjectMeta.Name, err, nil)
     return
   }
   var cniResult *current.Result


### PR DESCRIPTION
Fix issue where in meta CNI where if an error during createNic()
might result in a possible nil pointer dereference during error
handling

**What type of PR is this?**
bug

**What does this PR give to us**:
A fix for issue #198 . Maybe not in the right way - please review and let me know.

**Which issue(s) this PR fixes**
Fixes #198 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE