### PR TITLE
Fixing default table route management to work in all dual-stack cases

### DIFF
--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -137,11 +137,11 @@ func addIpToLink(ip string, iface netlink.Link) error {
 
 func addIpRoutes(ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
   defaultRoutingTable := 0
-  err := addRoutes(dnet.Spec.Options.Routes, defaultRoutingTable)
+  err := addRoutes(dnet.Spec.Options.Routes, ep.Spec.Iface.Address, defaultRoutingTable)
   if err != nil {
     return err
   }
-  err = addRoutes(dnet.Spec.Options.Routes6, defaultRoutingTable)
+  err = addRoutes(dnet.Spec.Options.Routes6, ep.Spec.Iface.AddressIPv6, defaultRoutingTable)
   if err != nil {
     return err
   }
@@ -156,8 +156,8 @@ func addIpRoutes(ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
   return nil
 }
 
-func addRoutes(routes map[string]string, rtable int) error {
-  if routes == nil {
+func addRoutes(routes map[string]string, allocatedIp string, rtable int) error {
+  if routes == nil || allocatedIp == "" || allocatedIp == ipam.NoneAllocType {
     return nil
   }
   for key, value := range routes {
@@ -189,7 +189,7 @@ func addRoutes(routes map[string]string, rtable int) error {
 }
 
 func addPolicyRoute(rtable int, cidr string, proutes map[string]string) error {
-  if rtable == 0 || cidr == ""  || cidr == ipam.NoneAllocType || proutes == nil {
+  if rtable == 0 || cidr == "" || cidr == ipam.NoneAllocType || proutes == nil {
     return nil
   }
   srcIp, srcNet, _ := net.ParseCIDR(cidr)
@@ -201,7 +201,7 @@ func addPolicyRoute(rtable int, cidr string, proutes map[string]string) error {
   if err != nil {
     return errors.New("cannot add rule for policy-based IP routes because:" + err.Error())
   }
-  err = addRoutes(proutes, rtable)
+  err = addRoutes(proutes, cidr, rtable)
   if err != nil {
     return err
   }


### PR DESCRIPTION
A dual-stack network can include both IPv4 and V6 CIDRs, allocation pools, and IP routes.
But not every Pod connecting to a DS network will have DS interfaces.

So, IP routes need to be selectively created; only if an IP was really assigned to the iterface from its respective domain.
Otherwise Linux throws a "no route to host" error during route creation, which in turn fails Pod instantiation.