### PR TITLE
Fix CRD IPv4/IPv6 CIDR validation pattern to strict

### DIFF
--- a/integration/crds/lightweight/DanmNet.yaml
+++ b/integration/crds/lightweight/DanmNet.yaml
@@ -32,7 +32,7 @@ spec:
                     maxLength: 0
                   - type: string
                     format: cidr
-                    pattern: '[\d./]+'
+                    pattern: '^\d+\.'
                 allocation_pool:
                   properties:
                     start:
@@ -53,7 +53,7 @@ spec:
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '[\d./]+'
+                        pattern: '^\d+\.'
                 container_prefix:
                   type: string
                 host_device:
@@ -81,7 +81,7 @@ spec:
                     maxLength: 0
                   - type: string
                     format: cidr
-                    pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                    pattern: ':'
                 allocation_pool_v6:
                   properties:
                     start:
@@ -102,14 +102,14 @@ spec:
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                        pattern: ':'
                     cidr:
                       oneOf:
                       - type: string
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                        pattern: ':'
                 routes:
                   type: object
                 routes6:

--- a/integration/crds/production/ClusterNetwork.yaml
+++ b/integration/crds/production/ClusterNetwork.yaml
@@ -36,7 +36,7 @@ spec:
                     maxLength: 0
                   - type: string
                     format: cidr
-                    pattern: '[\d./]+'
+                    pattern: '^\d+\.'
                 allocation_pool:
                   properties:
                     start:
@@ -57,7 +57,7 @@ spec:
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '[\d./]+'
+                        pattern: '^\d+\.'
                 container_prefix:
                   type: string
                 host_device:
@@ -85,7 +85,7 @@ spec:
                     maxLength: 0
                   - type: string
                     format: cidr
-                    pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                    pattern: ':'
                 allocation_pool_v6:
                   properties:
                     start:
@@ -106,14 +106,14 @@ spec:
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                        pattern: ':'
                     cidr:
                       oneOf:
                       - type: string
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                        pattern: ':'
                 routes:
                   type: object
                 routes6:

--- a/integration/crds/production/TenantNetwork.yaml
+++ b/integration/crds/production/TenantNetwork.yaml
@@ -32,7 +32,7 @@ spec:
                     maxLength: 0
                   - type: string
                     format: cidr
-                    pattern: '[\d./]+'
+                    pattern: '^\d+\.'
                 allocation_pool:
                   properties:
                     start:
@@ -53,7 +53,7 @@ spec:
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '[\d./]+'
+                        pattern: '^\d+\.'
                 container_prefix:
                   type: string
                 host_device:
@@ -81,7 +81,7 @@ spec:
                     maxLength: 0
                   - type: string
                     format: cidr
-                    pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                    pattern: ':'
                 allocation_pool_v6:
                   properties:
                     start:
@@ -102,14 +102,14 @@ spec:
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                        pattern: ':'
                     cidr:
                       oneOf:
                       - type: string
                         maxLength: 0
                       - type: string
                         format: cidr
-                        pattern: '([0-9a-fA-F]*:)+[\d.]*/\d+'
+                        pattern: ':'
                 routes:
                   type: object
                 routes6:


### PR DESCRIPTION
Kubernetes provides pre-defined [string validation formats](https://github.com/kubernetes/apiextensions-apiserver/blob/release-1.17/pkg/apis/apiextensions/v1/types_jsonschema.go#L27)
format: cidr - validates that string is valid IPv4 or IPv6 CIDR
Because we want to allow only one of them for each field value, adding a filter pattern solves this
In IPv4 CIDR case:
pattern: '^\d+\.' - pattern matches first IPv4 block + dot, first IPv6 block cannot be followed by dot
In IPv6 CIDR case:
pattern: ':' - pattern matches at least one colon in IPv6, there is no colon in IPv4

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
bug

**What does this PR give to us**:
Fixes an error during POD creation because CRD schema validation is erroneous for IPv6 related string fields in DanmNet, ClusternNetwork, TenantNetwork.
Causes following error:
`
<...> : Invalid value: "": "spec.Options.allocation_pool_v6.cidr" must validate one and only one schema (oneOf). Found none valid
<...> spec.Options.allocation_pool_v6.cidr: Invalid value: "": spec.Options.allocation_pool_v6.cidr in body should match '([0-9a-fA-F]*:)+[\d.]*/\d+'
`

**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The schema validation field 'format:' is officially supported from kubernetes 1.16, older releases may not support it.
```
