### PR TITLE
Fix kubernetes API deprecation in manifests

### DIFF
--- a/example/4_0_examples/10_good_deployment.yaml
+++ b/example/4_0_examples/10_good_deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-deployment
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: test-deployment
   replicas: 1
   template:
     metadata:

--- a/example/4_0_examples/11_allowed_default.yaml
+++ b/example/4_0_examples/11_allowed_default.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-deployment
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: test-deployment
   replicas: 1
   template:
     metadata:

--- a/example/4_0_examples/12_not_allowed_default.yaml
+++ b/example/4_0_examples/12_not_allowed_default.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-deployment
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: test-deployment
   replicas: 1
   template:
     metadata:

--- a/example/4_0_examples/9_wrong_deployment.yaml
+++ b/example/4_0_examples/9_wrong_deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-deployment
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      app: test-deployment
   replicas: 1
   template:
     metadata:

--- a/example/routes_and_proutes/pod_with_proutes.yaml
+++ b/example/routes_and_proutes/pod_with_proutes.yaml
@@ -1,8 +1,11 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: routed-deployment
 spec:
+  selector:
+    matchLabels:
+      app: routed
   replicas: 1
   template:
     metadata:

--- a/example/svcwatcher_demo/deployments/external_client.yaml
+++ b/example/svcwatcher_demo/deployments/external_client.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-client
   namespace: external-client
 spec:
+  selector:
+    matchLabels:
+      app: external-client
   replicas: 1
   template:
     metadata:

--- a/example/svcwatcher_demo/deployments/internal_processor.yaml
+++ b/example/svcwatcher_demo/deployments/internal_processor.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: internal-processor
   namespace: example-vnf
 spec:
+  selector:
+    matchLabels:
+      app: internal-processor
   replicas: 6
   template:
     metadata:

--- a/example/svcwatcher_demo/deployments/loadbalancer.yaml
+++ b/example/svcwatcher_demo/deployments/loadbalancer.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadbalancer
   namespace: example-vnf
 spec:
+  selector:
+    matchLabels:
+      app: loadbalancer
   replicas: 2
   template:
     metadata:

--- a/integration/bootstrap_networks/lightweight/flannel.yaml
+++ b/integration/bootstrap_networks/lightweight/flannel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: kube-system
 spec:
   NetworkID: flannel
-  NetworkType: flannel 
+  NetworkType: flannel

--- a/integration/bootstrap_networks/production/flannel.yaml
+++ b/integration/bootstrap_networks/production/flannel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: kube-system
 spec:
   NetworkID: flannel
-  NetworkType: flannel 
+  NetworkType: flannel

--- a/integration/cni_config/danm_rbac.yaml
+++ b/integration/cni_config/danm_rbac.yaml
@@ -1,6 +1,6 @@
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: caas:danm
 rules:
@@ -16,8 +16,8 @@ rules:
     resources: [ "pods" ]
     verbs: [ "get","watch","list"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: caas:danm
 roleRef:

--- a/integration/cni_config/example_kubeconfig.yaml
+++ b/integration/cni_config/example_kubeconfig.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
+kind: Config
+current-context: default
 clusters:
 - cluster:
     certificate-authority-data: ${CLUSTER_CA_CERTIFICATE}
@@ -9,10 +11,8 @@ contexts:
     cluster: ${CLUSTER_NAME}
     user: danm
   name: default
-current-context: default
-kind: Config
-preferences: {}
 users:
 - name: danm
   user:
     token: ${SERVICEACCOUNT_TOKEN}
+preferences: {}

--- a/integration/manifests/netwatcher/netwatcher_ds.yaml
+++ b/integration/manifests/netwatcher/netwatcher_ds.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         danm.k8s.io: netwatcher
     spec:
-      serviceAccount: netwatcher
+      serviceAccountName: netwatcher
       hostNetwork: true
       dnsPolicy: ClusterFirst
       hostIPC: true

--- a/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
+++ b/integration/manifests/svcwatcher/0svcwatcher_rbac.yaml
@@ -70,4 +70,3 @@ subjects:
 - kind: ServiceAccount
   namespace: kube-system
   name: svcwatcher
-

--- a/integration/manifests/svcwatcher/svcwatcher_ds.yaml
+++ b/integration/manifests/svcwatcher/svcwatcher_ds.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         danm.k8s.io: svcwatcher
     spec:
-      serviceAccount: svcwatcher
+      serviceAccountName: svcwatcher
       dnsPolicy: ClusterFirst
       nodeSelector:
         "node-role.kubernetes.io/master": ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
cleanup

**What does this PR give to us**:
When old `example` and `integration` manifests are used kubernetes emits deprecation warnings. This PR clears those warnings.

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
