### PR TITLE
Add installer job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,11 +6,11 @@
 
 .dockerignore
 scm/build/Dockerfile
+scm/build/Dockerfile.install
 
 build_danm.sh
 run_uts.sh
 
-integration/
 example/
 vendor/
 ut/

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -55,7 +55,15 @@ The result will four container images:
 
 ## Deployment
 
-The method of deploying the whole DANM suite into a Kubernetes cluster is the following.
+As a quicker but currently experimental option, please also take a look at
+[Deploying using an installer job](deployment-installer-job.md). This option integrates all
+of the steps mentioned below, into a single one-stop-shop installer. However, please treat
+this option as experimental for now -- and only apply it on a Kubernetes cluster where you
+feel comfortable with tolerating the impact if something goes wrong. Also, please let
+us know any issues you encounter!
+
+Otherwise, the manual method of deploying the whole DANM suite into a Kubernetes cluster is
+the following:
 
 ### 1. Extend the Kubernetes API
 

--- a/deployment-installer-job.md
+++ b/deployment-installer-job.md
@@ -1,0 +1,84 @@
+# Deployment via installer job
+
+
+## TL;DR;
+
+```
+${EDITOR} integration/install/danm-installer-config.yaml
+kubectl apply -f integration/install
+```
+
+## Installer job
+
+This (currently experimental) method installs DANM using a Kubernetes Job.
+
+Just like the manual deployment, it assumes that a previous CNI (also referred to
+as "bootstrap CNI") is already installed. In the setup deployed by this installer,
+the bootstrap CNI will both be used by DANM components themselves (ie. netwatcher
+and svcwatcher will utilize that bootstrap CNI for their own network connectivity),
+as well as being configured as a DanmNet or ClusterNetwork with the name "default",
+that will be used by any Kubernetes applications without a `danm.k8s.io` annotation.
+
+Please be aware that the existing (bootstrap) CNI configuration must be a single
+CNI, *not* a list of CNIs. This means that in your CNI configuration directory,
+`/etc/cni/net.d`, there should be an existing file with a `.conf` extension, often
+named something like `10-flannel.conf` or `10-calico.conf`.
+
+If there is a file with a `.conflist` extension (such as `10-calico.conflist`), then
+that is a chained list of multiple CNIs. DANM does not currently support using
+such a `.conflist` chain as a bootstrap network. Depending on your setup, you may be
+able to to extract only the first CNI from the list using a command such as the
+following:
+
+```
+jq -M '{ name: .name, cniVersion: .cniVersioni} + .plugins[0]' \
+  /etc/cni/net.d/${EXISTING_CONFLIST_FILE}.conflist \
+  > /etc/cni/net.d/${FIRST_PLUGIN_FROM_LIST_CONFIG_FILE}.conf
+```
+
+Either way, please be sure that you have a functional `/etc/cni/net.d/*.conf` CNI
+configuration before proceeding, and know the name of that `.conf` file.
+
+
+### Configuration file (configMap)
+
+This file will need modification to match your setup.
+
+Please review/edit `integration/install/danm-installer-config.yaml`.
+
+
+### Installer Job resource
+
+This file will need modification only if the installation container needs to be
+pulled from an external registry. If this is the case, then please review/edit
+`integration/install/danm-installer.yaml`.
+
+If you have built DANM locally and do not need to pull images, this file does not
+need updating.
+
+
+### Deploying the installer
+
+```
+kubectl apply -f integration/install
+```
+
+
+### Watching installer progress
+
+After applying the installer CRD, in `kubectl get pods -n kube-system` you should
+first see a `danm-installer-*` pod starting, and shortly after, the
+`danm-cni` and `netwatcher` daemonsets, `svcwatcher`, and `danm-webhook-deployment`
+pods.
+
+The `danm-installer-*` pod should end up in "Completed" status - if not, please check
+the pod logs for any errors.
+
+
+### Cleaning up (optional)
+
+After the installer pod ran to completion, you can remove the installer itself:
+
+```
+kubectl delete -f integration/install
+```

--- a/integration/install/0danm-installer-rbac.yaml
+++ b/integration/install/0danm-installer-rbac.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: danm-installer
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: caas:danm-installer
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: [ "*" ]
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - create
+  - patch
+- apiGroups:
+  - "*"
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - "*"
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - danm.k8s.io
+  resources:
+  - clusternetworks
+  - danmeps
+  - danmnets
+  - tenantnetworks
+  - tenantconfigs
+  verbs:
+  - "*"
+- apiGroups:
+  - "apps"
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - get
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - get
+  - create
+  - patch
+- apiGroups:
+  - "certificates.k8s.io"
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - delete
+  - get
+  - create
+  - update
+- apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: caas:danm-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: caas:danm-installer
+subjects:
+- kind: ServiceAccount
+  name: danm-installer
+  namespace: kube-system

--- a/integration/install/danm-installer-config.yaml
+++ b/integration/install/danm-installer-config.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: danm-installer-config
+data:
+  #
+  # DANM deployment mode. This MUST be either "lightweight" or "production". Please see the DANM user guide for
+  # details on the two modes.
+  #
+  deploy_mode: production
+
+  #
+  # CNI configuration directory. Typically, this is "/etc/cni/net.d". This is the directory where your
+  # current (bootstrap) CNI configuration is located, too.
+  #
+  cni_dir: /etc/cni/net.d
+
+  #
+  # CNI naming scheme. See section "Naming container interfaces" in the user guide for a more detailed
+  # discussion. Set this parameter to "legacy" if you wish container interface names to be set exactly
+  # according to DanmNet.Spec.Options.container_prefix, or to an empty string if you wish the first
+  # interface to always be named "eth0".
+  #
+  cni_naming_scheme: ""
+
+  #
+  # [OPTIONAL] Kubernetes API Root CA certificate. If left blank, the installer will obtain the
+  # API server certificate from the Kubernetes API. Note, however, that placing a certificate here
+  # is technically more secure (as it provides external verification of the CA certificate, rather
+  # than blindly trusting the certificate that we see from the server) and also more future-proof
+  # if the individual API server's certificate ever were to change in the future, to put the Root
+  # CA certificate here. You can obtain this, for example, by running:
+  #
+  # kubectl config view \
+  #   --flatten \
+  #   -o jsonpath='{.clusters[0].cluster.certificate-authority-data} \
+  #   | base64 -d
+  #
+#  api_ca_cert: |
+#    -----BEGIN CERTIFICATE-----
+#    VGhpcyBJcyBBIFBsYWNlaG9sZGVyIFN0cmluZy4uLiBUaGlzIElzIEEgUGxhY2Vo
+#    ...
+#    VGhpcyBpcyB0aGUgZW5kIG9mIGEgcGxhY2Vob2xkZXIgc3RyaW5nCg==
+#    -----END CERTIFICATE-----
+
+  #
+  # This is the type of the CNI plugin used for your default (bootstrap) network.
+  # The value can also be found in the "type" field of your bootstrap CNI configuration
+  # file, eg. "cat ${cni_dir}/${default_cni_network_id}.conf | jq -Mr '.type'"
+  #
+  default_cni_type: flannel
+
+  #
+  # The name of your bootstrap CNI configuration file, without the `.conf` extension.
+  # This means that on each node in your cluster, in the ${cni_dir} directory, a file
+  # with the name of "${default_cni_network_id}.conf" must exist. Alternatively,
+  # a file with this name will be created if the ${default_cni_config_data} parameter
+  # is also provided (below).
+  #
+  default_cni_network_id: 10-flannel
+
+  #
+  # [OPTIONAL] Bootstrap CNI configuration data. Typically, your bootstrap CNI plugin
+  # should already be configured, so using this option should not be necessary. However,
+  # there may be situations where using this option may be useful to distribute an
+  # alternative configuration file for your bootstrap CNI plugin. If provided, the
+  # contents of this variable are going to be written to a file named
+  # "${default_cni_network_id}.conf" as above.
+  #
+#  default_cni_config_data: |
+#    {
+#      "cniVersion": "0.3.1",
+#      "type": "flannel",
+#      "delegate": {
+#        "hairpinMode": true,
+#        "isDefaultGateway": true
+#      }
+#    }
+
+  #
+  # [OPTIONAL] A prefix (such as a registry name) to be included in each container image.
+  # Note that this can be any prefix you like, but if it is a registry name, then
+  # the value specified here needs to include the trailing slash.
+  #
+  # For example, if you wish to pull your "netwatcher" image from
+  # "my-registry.example.com/namespace/netwatcher", then set this value to
+  # "my-registry.example.com/namespace/". The same prefix will be applied for
+  # all images.
+  #
+#  image_registry_prefix: my-registry.example.com/namespace/
+
+  #
+  # [OPTIONAL] Image tag for each image. Defaults to "latest" if none specified.
+  #
+#  image_tag: latest
+
+  #
+  # [OPTIONAL] If your registry needs authentication, then this is the name
+  # of a Kubernetes secret with registry credentials. This secret must already
+  # exist and is not created by the installer.
+  #
+#  image_pull_secret: my-registry-secret
+
+  #
+  # Image Pull policy. Can be "Always", "Never", or "IfNotPresent".
+  #
+  image_pull_policy: IfNotPresent

--- a/integration/install/danm-installer.yaml
+++ b/integration/install/danm-installer.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: danm-installer
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      serviceAccountName: danm-installer
+      containers:
+        - name: danm-installer
+          volumeMounts:
+            - name: danm-installer-config
+              mountPath: /config
+
+          # Update the next two lines as needed
+          image: damn-installer:latest
+          imagePullPolicy: IfNotPresent
+
+      volumes:
+        - name: danm-installer-config
+          configMap:
+            name: danm-installer-config
+      terminationGracePeriodSeconds: 0
+      restartPolicy: OnFailure
+
+      # Add this if needed:
+#      imagePullSecrets:
+#        - name: my-registry-secret

--- a/integration/manifests/cni_plugins/cni_plugins_ds.yaml
+++ b/integration/manifests/cni_plugins/cni_plugins_ds.yaml
@@ -16,12 +16,18 @@ spec:
       containers:
         - name: danm-cni
           image: danm-cni-plugins
+          imagePullPolicy: {{ (getenv "IMAGE_PULL_POLICY") }}
           volumeMounts:
-            - name: cni
+            - name: host-cni
               mountPath: /host/cni
+            - name: host-net-d
+              mountPath: /host/net.d
       hostNetwork: true
       terminationGracePeriodSeconds: 0
       volumes:
-        - name: cni
+        - name: host-cni
           hostPath:
             path: /opt/cni/bin
+        - name: host-net-d
+          hostPath:
+            path: /etc/cni/net.d

--- a/integration/manifests/cni_plugins/cni_plugins_ds.yaml.tmpl
+++ b/integration/manifests/cni_plugins/cni_plugins_ds.yaml.tmpl
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: danm-cni
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      danm.k8s.io: danm-cni
+  template:
+    metadata:
+      labels:
+        danm.k8s.io: danm-cni
+    spec:
+      containers:
+        - name: danm-cni
+          image: {{ getenv "IMAGE_REGISTRY_PREFIX" }}danm-cni-plugins{{ getenv "IMAGE_TAG" }}
+          volumeMounts:
+            - name: host-cni
+              mountPath: /host/cni
+            - name: host-net-d
+              mountPath: /host/net.d
+            - name: config
+              mountPath: /config
+{{- if getenv "IMAGE_PULL_SECRET" }}
+      imagePullSecrets:
+        - name: {{ getenv "IMAGE_PULL_SECRET" }}
+{{- end }}
+      hostNetwork: true
+      terminationGracePeriodSeconds: 0
+      volumes:
+        - name: host-cni
+          hostPath:
+            path: /opt/cni/bin
+        - name: host-net-d
+          hostPath:
+            path: {{ getenv "CNI_DIR" }}
+        - name: config
+          secret:
+            secretName: danm-config

--- a/integration/manifests/netwatcher/netwatcher_ds.yaml.tmpl
+++ b/integration/manifests/netwatcher/netwatcher_ds.yaml.tmpl
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netwatcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      danm.k8s.io: netwatcher
+  template:
+    metadata:
+      labels:
+        danm.k8s.io: netwatcher
+    spec:
+      serviceAccountName: netwatcher
+      hostNetwork: true
+      dnsPolicy: ClusterFirst
+      hostIPC: true
+      hostPID: true
+      containers:
+        - name: netwatcher
+          image: {{ getenv "IMAGE_REGISTRY_PREFIX" }}netwatcher{{ getenv "IMAGE_TAG" }}
+          imagePullPolicy: {{ (getenv "IMAGE_PULL_POLICY") }}
+          securityContext:
+            capabilities:
+              add:
+                - SYS_PTRACE
+                - SYS_ADMIN
+                - NET_ADMIN
+                - NET_RAW
+{{- if getenv "IMAGE_PULL_SECRET" }}
+      imagePullSecrets:
+        - name: {{ getenv "IMAGE_PULL_SECRET" }}
+{{- end }}
+      tolerations:
+       - effect: NoSchedule
+         operator: Exists
+       - effect: NoExecute
+         operator: Exists
+      terminationGracePeriodSeconds: 0

--- a/integration/manifests/svcwatcher/svcwatcher_ds.yaml.tmpl
+++ b/integration/manifests/svcwatcher/svcwatcher_ds.yaml.tmpl
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: svcwatcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      danm.k8s.io: svcwatcher
+  template:
+    metadata:
+      labels:
+        danm.k8s.io: svcwatcher
+    spec:
+      serviceAccountName: svcwatcher
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        "node-role.kubernetes.io/master": ""
+      containers:
+        - name: svcwatcher
+          image: {{ getenv "IMAGE_REGISTRY_PREFIX" }}svcwatcher{{ getenv "IMAGE_TAG" }}
+          imagePullPolicy: {{ (getenv "IMAGE_PULL_POLICY") }}
+          args:
+            - "--logtostderr"
+{{- if getenv "IMAGE_PULL_SECRET" }}
+      imagePullSecrets:
+        - name: {{ getenv "IMAGE_PULL_SECRET" }}
+{{- end }}
+      tolerations:
+       - effect: NoSchedule
+         operator: Exists
+       - effect: NoExecute
+         operator: Exists
+      terminationGracePeriodSeconds: 0

--- a/integration/manifests/webhook/webhook-create-signed-cert.sh
+++ b/integration/manifests/webhook/webhook-create-signed-cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ EOF
     exit 1
 }
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case ${1} in
         --service)
             service="$2"
@@ -105,12 +105,12 @@ kubectl certificate approve ${csrName}
 # verify certificate has been signed
 for x in $(seq 10); do
     serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
-    if [[ ${serverCert} != '' ]]; then
+    if [ -n ${serverCert} ]; then
         break
     fi
     sleep 1
 done
-if [[ ${serverCert} == '' ]]; then
+if [ -z ${serverCert} ]; then
     echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
     exit 1
 fi

--- a/integration/manifests/webhook/webhook.yaml.tmpl
+++ b/integration/manifests/webhook/webhook.yaml.tmpl
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: danm-webhook
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: caas:danm-webhook
+rules:
+- apiGroups:
+  - danm.k8s.io
+  resources:
+  - tenantconfigs
+  - danmeps
+  verbs: [ "*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: caas:danm-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: caas:danm-webhook
+subjects:
+- kind: ServiceAccount
+  name: danm-webhook
+  namespace: kube-system
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: danm-webhook-config
+  namespace: kube-system
+webhooks:
+  - name: danm-netvalidation.nokia.k8s.io
+    clientConfig:
+      service:
+        name: danm-webhook-svc
+        namespace: kube-system
+        path: "/netvalidation"
+      caBundle: {{ base64Encode (getenv "KUBERNETES_CA_CERTIFICATE") }}
+    rules:
+      # UPDATE IS TEMPORARILY REMOVED DUE TO:https://github.com/nokia/danm/issues/144
+      - operations: ["CREATE"]
+        apiGroups: ["danm.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["danmnets","clusternetworks","tenantnetworks"]
+    failurePolicy: Fail
+  - name: danm-configvalidation.nokia.k8s.io
+    clientConfig:
+      service:
+        name: danm-webhook-svc
+        namespace: kube-system
+        path: "/confvalidation"
+      caBundle: {{ base64Encode (getenv "KUBERNETES_CA_CERTIFICATE") }}
+    rules:
+      - operations: ["CREATE","UPDATE"]
+        apiGroups: ["danm.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["tenantconfigs"]
+    failurePolicy: Fail
+  - name: danm-netdeletion.nokia.k8s.io
+    clientConfig:
+      service:
+        name: danm-webhook-svc
+        namespace: kube-system
+        path: "/netdeletion"
+      caBundle: {{ base64Encode (getenv "KUBERNETES_CA_CERTIFICATE") }}
+    rules:
+      - operations: ["DELETE"]
+        apiGroups: ["danm.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["danmnets","clusternetworks","tenantnetworks"]
+    failurePolicy: Fail
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: danm-webhook-svc
+  namespace: kube-system
+  labels:
+    danm: webhook
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    danm: webhook
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: danm-webhook-deployment
+  namespace: kube-system
+  labels:
+    danm: webhook
+spec:
+  selector:
+    matchLabels:
+     danm: webhook
+  template:
+    metadata:
+      name: danm-webhook
+      labels:
+        danm: webhook
+    spec:
+      serviceAccountName: danm-webhook
+      containers:
+        - name: danm-webhook
+          image: {{ getenv "IMAGE_REGISTRY_PREFIX" }}webhook{{ getenv "IMAGE_TAG" }}
+          command: [ "/usr/local/bin/webhook", "-tls-cert-bundle=/etc/webhook/certs/cert.pem", "-tls-private-key-file=/etc/webhook/certs/key.pem", "bind-port=8443" ]
+          imagePullPolicy: {{ (getenv "IMAGE_PULL_POLICY") }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+{{- if getenv "IMAGE_PULL_SECRET" }}
+      imagePullSecrets:
+        - name: {{ getenv "IMAGE_PULL_SECRET" }}
+{{- end }}
+      # Configure the directory holding the Webhook's server certificates
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: danm-webhook-certs

--- a/scm/build/Dockerfile.install
+++ b/scm/build/Dockerfile.install
@@ -1,0 +1,29 @@
+FROM alpine:latest
+ARG USERNAME=danm
+ARG UID=147
+ARG GID=147
+
+ARG KUBECTL_VERSION=1.17.4
+ARG CONFD_VERSION=0.16.0
+
+RUN adduser -u ${UID} -D -H -s /bin/sh ${USERNAME} \
+ && apk add --no-cache jq openssl \
+ && wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+ && mv kubectl /usr/local/bin/kubectl \
+ && chmod 755 /usr/local/bin/kubectl \
+ && wget https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 \
+ && mv confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd \
+ && chmod 755 /usr/local/bin/confd
+
+COPY integration /integration
+COPY scm/build/install/install.sh /
+COPY scm/build/install/confd /etc/confd/
+
+RUN mkdir /config-out \
+ && chown ${UID}:${GID} /config-out \
+ && chown -R ${UID}:${GID} /integration \
+ && chown -R ${UID}:${GID} /etc/confd/templates
+
+WORKDIR /
+USER ${USERNAME}
+ENTRYPOINT ["/install.sh"]

--- a/scm/build/cni_ds/entrypoint.sh
+++ b/scm/build/cni_ds/entrypoint.sh
@@ -1,16 +1,48 @@
 #!/bin/sh -e
 
 echo "Copying plugins..."
-
-# Copy files into place and atomically move into final binary name
 for plugin in /cni/*
 do
   plugin=$(basename "${plugin}")
 
   echo "  - ${plugin}"
-  cp -fa /cni/"${plugin}" /host/cni/_"${plugin}"
-  mv -f  /host/cni/_"${plugin}" /host/cni/"${plugin}"
+  # Copy files into place and atomically move into final binary name
+  cp -fa "/cni/${plugin}" "/host/cni/_${plugin}"
+  mv -f  "/host/cni/_${plugin}" "/host/cni/${plugin}"
 done
 
+if [ -e /config ]
+then
+  echo "Copy configuration files..."
+  bootstrap_network=$(cat /config/bootstrap_network)
+
+  if [ -e /config/bootstrap_cni_config_data ]
+  then
+    # If we were given a bootstrap config, then copy it. This may be useful
+    # in scenarios where the user originally had a .conflist file installed,
+    # and wants to distribute a flat bootstrap CNI configuration alongside
+    # with DANM.
+    cat /config/bootstrap_cni_config_data | base64 -d > /host/net.d/_${bootstrap_network}.conf
+    mv -f /host/net.d/_${bootstrap_network}.conf /host/net.d/${bootstrap_network}.conf
+  fi
+
+  if [ ! -f "/host/net.d/${bootstrap_network}.conf" ]
+  then
+    echo "Bootstrap network configuration ${bootstrap_network} is expected to be exist,"
+    echo "but file ${bootstrap_network}.conf does not exist."
+    exit 1
+  fi
+
+  # Copy kubeconfig
+  cp -f /config/danm-kubeconfig /host/net.d/_danm-kubeconfig
+  mv -f /host/net.d/_danm-kubeconfig /host/net.d/danm-kubeconfig
+  chmod 0600 /host/net.d/danm-kubeconfig
+
+  # Copy DANM configuration. Do this last, in order to minimize the risk of leaving the
+  # host in an inoperable state if any of the previous steps failed.
+  cp -f /config/00-danm.conf /host/net.d/_00-danm.conf
+  mv -f /host/net.d/_00-danm.conf /host/net.d/00-danm.conf
+fi
+  
 echo "Done. Sleeping..."
 sleep infinity

--- a/scm/build/install/confd/conf.d/cni_plugins_ds.toml
+++ b/scm/build/install/confd/conf.d/cni_plugins_ds.toml
@@ -1,0 +1,3 @@
+[template]
+src = "cni_plugins_ds.yaml.tmpl"
+dest = "/integration/manifests/cni_plugins/cni_plugins_ds.yaml"

--- a/scm/build/install/confd/conf.d/danm-config.toml
+++ b/scm/build/install/confd/conf.d/danm-config.toml
@@ -1,0 +1,3 @@
+[template]
+src = "danm-config.yaml.tmpl"
+dest = "/config-out/resources/danm-config.yaml"

--- a/scm/build/install/confd/conf.d/default-net.toml
+++ b/scm/build/install/confd/conf.d/default-net.toml
@@ -1,0 +1,3 @@
+[template]
+src = "default-net.yaml.tmpl"
+dest = "/config-out/resources/default-net.yaml"

--- a/scm/build/install/confd/conf.d/netwatcher_ds.toml
+++ b/scm/build/install/confd/conf.d/netwatcher_ds.toml
@@ -1,0 +1,3 @@
+[template]
+src = "netwatcher_ds.yaml.tmpl"
+dest = "/integration/manifests/netwatcher/netwatcher_ds.yaml"

--- a/scm/build/install/confd/conf.d/svcwatcher_ds.toml
+++ b/scm/build/install/confd/conf.d/svcwatcher_ds.toml
@@ -1,0 +1,3 @@
+[template]
+src = "svcwatcher_ds.yaml.tmpl"
+dest = "/integration/manifests/svcwatcher/svcwatcher_ds.yaml"

--- a/scm/build/install/confd/conf.d/webhool.toml
+++ b/scm/build/install/confd/conf.d/webhool.toml
@@ -1,0 +1,3 @@
+[template]
+src = "webhook.yaml.tmpl"
+dest = "/integration/manifests/webhook/webhook.yaml"

--- a/scm/build/install/confd/templates/danm-config.yaml.tmpl
+++ b/scm/build/install/confd/templates/danm-config.yaml.tmpl
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: kube-system
+  name: danm-config
+type: Opaque
+stringData:
+  bootstrap_network: {{ getenv "DEFAULT_CNI_NETWORK_ID" }}
+  00-danm.conf: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "danm_meta_cni",
+      "type": "danm",
+      "kubeconfig": "{{ getenv "CNI_DIR" }}/danm-kubeconfig",
+      "cniDir": "{{ getenv "CNI_DIR" }}",
+      "namingScheme": "{{ getenv "CNI_NAMING_SCHEME" }}"
+    }
+  danm-kubeconfig: |
+    ---
+    apiVersion: v1
+    kind: Config
+    current-context: default
+    clusters:
+      - cluster:
+          certificate-authority-data: {{ base64Encode (getenv "KUBERNETES_CA_CERTIFICATE") }}
+          server: https://{{ getenv "KUBERNETES_HOST_PORT" }}
+        name: kubernetes
+    contexts:
+      - context:
+          cluster: kubernetes
+          user: danm
+        name: default
+    users:
+      - name: danm
+        user:
+          token: {{ getenv "SERVICEACCOUNT_TOKEN" }}
+    preferences: {}
+{{- if getenv "DEFAULT_CNI_CONFIG_DATA" }}
+  bootstrap_cni_config_data: {{ base64Encode (getenv "DEFAULT_CNI_CONFIG_DATA") }}
+{{- end }}

--- a/scm/build/install/confd/templates/default-net.yaml.tmpl
+++ b/scm/build/install/confd/templates/default-net.yaml.tmpl
@@ -1,0 +1,9 @@
+---
+apiVersion: danm.k8s.io/v1
+kind: {{ if eq (getenv "DANM_DEPLOY_MODE") "lightweight" }}DanmNet{{ else }}ClusterNetwork{{ end }}
+metadata:
+  name: default
+  namespace: kube-system
+spec:
+  NetworkID: {{ getenv "DEFAULT_CNI_NETWORK_ID" }}
+  NetworkType: {{ getenv "DEFAULT_CNI_TYPE" }}

--- a/scm/build/install/install.sh
+++ b/scm/build/install/install.sh
@@ -1,0 +1,132 @@
+#!/bin/sh -e
+
+#
+# Do some basic sanity testing around configuration parameters
+#
+for required_config in deploy_mode cni_dir cni_naming_scheme default_cni_type default_cni_network_id
+do
+  if [ -f "${required_config}" ]
+  then
+    echo "configuration item: \"${required_config}\" must be configured"
+    exit 1
+  fi
+done
+
+export DANM_DEPLOY_MODE=$(cat /config/deploy_mode)
+if [ "${DANM_DEPLOY_MODE}" != "lightweight" ] && [ "${DANM_DEPLOY_MODE}" != "production" ]
+then
+  echo "\"deploy_mode\" must be either \"lightweight\" or \"production\""
+  exit 1
+fi
+
+export CNI_DIR=$(cat /config/cni_dir)
+export CNI_NAMING_SCHEME=$(cat /config/cni_naming_scheme)
+export DEFAULT_CNI_TYPE=$(cat /config/default_cni_type)
+export DEFAULT_CNI_NETWORK_ID=$(cat /config/default_cni_network_id)
+export IMAGE_PULL_POLICY=$(cat /config/image_pull_policy)
+
+if [ -f /config/image_registry_prefix ]
+then
+  export IMAGE_REGISTRY_PREFIX="$(cat /config/image_registry_prefix)"
+  echo "Using configured image registry prefix: ${IMAGE_REGISTRY_PREFIX}"
+else
+  echo "Not using any image registry prefix"
+fi
+
+if [ -f /config/image_tag ]
+then
+  export IMAGE_TAG=":$(cat /config/image_tag)"
+  echo "Using configured image tag: ${IMAGE_TAG}"
+else
+  echo "Not using any image tag"
+fi
+
+if [ -f /config/image_pull_secret ]
+then
+  export IMAGE_PULL_SECRET="$(cat /config/image_pull_secret)"
+  echo "Using configured image pull secret: ${IMAGE_PULL_SECRET}"
+else
+  echo "Not using any image pull secret"
+fi
+
+if [ -f /config/default_cni_config_data ]
+then
+  export DEFAULT_CNI_CONFIG_DATA="$(cat /config/default_cni_config_data)"
+  echo "Using supplied CNI configuration data"
+fi
+
+# We need to get the API server's CA certificate. That is easier said than done. We can glean the server's
+# certificate by connecting to it. However, what we'd REALLY want to get, is the *ROOT* CA certificate, and
+# not just the individual server certificate. The root CA certificate, however, is nowhere to be found
+# programatically.
+#
+# We can retrieve that from a configmap, of course - but that requires the user to put it there,
+# which puts some of the effort back on the user that we wanted to avoid. So, providing two options:
+# 1) Read the root cert (or any cert) if provided via configmap, or else 2) read the server
+# certificate and make do with that.
+if [ -f /config/api_ca_cert ]
+then
+  echo ; echo "Using supplied CA certificate"
+  export KUBERNETES_CA_CERTIFICATE="$(cat /config/api_ca_cert)"
+else
+  echo ; echo "Reading Kubernetes API server certificate"
+  export KUBERNETES_CA_CERTIFICATE="$(openssl s_client -connect ${KUBERNETES_HOST_PORT} 2>&1 </dev/null | sed -ne '/BEGIN CERT/,/END CERT/p')"
+fi
+
+#
+# Apply API extension CRDs
+#
+echo ; echo "Applying CRDs to extend Kubernetes API..."
+kubectl apply -f /integration/crds/${DANM_DEPLOY_MODE}
+
+#
+# Create Service-Account user
+#
+# Try to create the account; don't be fussy if it already exists
+#
+echo ; echo "Creating Service Account"
+kubectl create --namespace kube-system serviceaccount danm || true
+kubectl apply -f /integration/cni_config/danm_rbac.yaml
+
+#
+# Create CSR and certificate (using existing script)
+#
+echo ; echo "Creating WebHook certificate..."
+/integration/manifests/webhook/webhook-create-signed-cert.sh
+
+#
+# Render templated resources: CNI DaemonSet configuration, CNI DaemonSet,
+#   default network, netwatcher
+#
+echo ; echo "Rendering configuration templates"
+
+SECRET_NAME="$(kubectl get --namespace kube-system -o jsonpath='{.secrets[0].name}' serviceaccounts danm)"
+export SERVICEACCOUNT_TOKEN="$(kubectl get --namespace kube-system secrets ${SECRET_NAME} -o jsonpath='{.data.token}' | base64 -d)"
+export KUBERNETES_HOST_PORT="$(echo ${KUBERNETES_PORT} | cut -f 3 -d '/')"
+
+mkdir -p /config-out/resources
+# It seems confd really does not want to render templates with absolute paths - so we
+# need to link in a few externals
+ln -sf /integration/manifests/cni_plugins/cni_plugins_ds.yaml.tmpl /etc/confd/templates/cni_plugins_ds.yaml.tmpl
+ln -sf /integration/manifests/netwatcher/netwatcher_ds.yaml.tmpl /etc/confd/templates/netwatcher_ds.yaml.tmpl
+ln -sf /integration/manifests/webhook/webhook.yaml.tmpl /etc/confd/templates/webhook.yaml.tmpl
+ln -sf /integration/manifests/svcwatcher/svcwatcher_ds.yaml.tmpl /etc/confd/templates/svcwatcher_ds.yaml.tmpl
+
+confd -onetime
+
+echo ; echo "Applying DANM CNI DS configuration and default network..."
+kubectl apply -f /config-out/resources/
+
+echo ; echo "Creating DANM CNI DaemonSet..."
+kubectl apply -f /integration/manifests/cni_plugins
+
+echo ; echo "Creating NetWatcher DaemonSet..."
+kubectl apply -f /integration/manifests/netwatcher
+
+echo ; echo "Creating Webhook..."
+kubectl apply -f /integration/manifests/webhook
+
+echo ; echo "Creating SvcWatcher..."
+kubectl apply -f /integration/manifests/svcwatcher
+
+echo ; echo "Done."


### PR DESCRIPTION
Adds an alternate method of installing by running a Kubernetes Job.
See file "deployment-installer-job.md" in this commit for a detailed
description of the job.

**What type of PR is this?**
feature

**What does this PR give to us**:
A simple installer job

**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #35 

**Special notes for your reviewer**:
With this change in place, it might actually make sense to pre-build DANM and upload to DockerHub? That would even further simplify the deployment.

A Helm chart might be yet another option, but I don't know of a good way to do the Kubernetes CA integration (issuing the CSR, getting it signed) by Helm alone. It seems that that would still require a job of sort; some other users seem to be using https://github.com/jet/kube-webhook-certgen for that purpose?). In any case, this provides one option that works in environments where Helm is not available, too.

In hindsight, I feel rather silly for having mounted the installer configmap as file mounts (rather than mounting the configmap as environment variables). At the start, I thought there'd be more cases of directly manipulating files -- but they all disappeared over the time, and what's left now, is largely a construct where most mounted files are directly read into environment variables.

Note that this change currently leaves two versions of netwatcher/webhook/cni-daemonset/svcwatcher manifests -- the original example files, and a `.tmpl` file for automated parsing. There may be an opportunity to remove the "manual deployment" example files at a later date.

**Does this PR introduce a user-facing change?**:
```release-note
See deployment-installer-job.md for an alternative (simpler, but currently experimental) method
to deploy.
```
