### PR TITLE
Additional fix to installer CSR signername and webhook

### DIFF
--- a/integration/manifests/webhook/webhook-create-signed-cert.sh
+++ b/integration/manifests/webhook/webhook-create-signed-cert.sh
@@ -86,7 +86,6 @@ spec:
   groups:
   - system:authenticated
   request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
-  signerName: kubernetes.io/legacy-unknown
   usages:
   - digital signature
   - key encipherment

--- a/scm/build/Dockerfile
+++ b/scm/build/Dockerfile
@@ -32,7 +32,7 @@ RUN scm/build/build.sh \
 # (Intermediate) Stage: Alping base image. Includes common user account and environment
 #                       for netwatcher, svcwatcher, webhook
 #
-FROM alpine:latest AS base-alpine
+FROM alpine:3.11 AS base-alpine
 ARG USERNAME
 ARG UID
 ARG GID
@@ -80,7 +80,7 @@ ENTRYPOINT ["/usr/local/bin/webhook"]
 # Note that unlike the other containers, this needs to run as root as
 # it places CNI plugins into the host's filesystem.
 #
-FROM alpine:latest AS danm-cni-plugins
+FROM alpine:3.11 AS danm-cni-plugins
 
 VOLUME ["/host/cni"]
 


### PR DESCRIPTION
It seems that including the signerName in RBAC is optional in 1.17
(and before?), but required as of 1.18.

Including signerName in the CSR itself, is optional in 1.18 but
NOT supported in 1.17 or earlier.

Hence, removing signerName from the CSR creation again. This may need
to be revisited later.

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
bug

**What does this PR give to us**:
Bugfix to previous code commit regarding CSR signerName. Unfortunately, the previous commit,
while fixing an issue for 1.18, broke older releases :(

**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE