### PR TITLE
Adding automatic setting of ndisc_notify kernel parameter to 1 on all DANM managed V6 interfaces

### DIFF
--- a/pkg/danmep/danmep.go
+++ b/pkg/danmep/danmep.go
@@ -40,6 +40,7 @@ var sysctls = []sysctlTask {
       {"net.ipv6.conf.%s.disable_ipv6", "0"},
       {"net.ipv6.conf.%s.autoconf", "0"},
       {"net.ipv6.conf.%s.accept_ra", "0"},
+      {"net.ipv6.conf.%s.ndisc_notify", "1"},
     },
   },
   {


### PR DESCRIPTION
This is required to ensure when a previously allocated IP moves to another host the change is propagated throughout the fabric.
In case of IPv4 we achieve the same effect by sending a gARP Reply through the interface, but this mechanism does not exist for IPv6. Previously we thought it is because such mechanism happens automatically in the kernel, however as we recently found out this functionality seemed to be configurable via the ndisc_notify kernel setting:
https://sysctl-explorer.net/net/ipv6/ndisc_notify/