### PR TITLE
Restrict post-processing to kernel network interfaces

### DIFF
--- a/pkg/danmep/danmep.go
+++ b/pkg/danmep/danmep.go
@@ -54,6 +54,7 @@ var sysctls = []sysctlTask {
 const (
   MaxRetryCount = 10
   RetryInterval = 100
+  V6SysPath     = "/proc/sys/net/ipv6/conf/"
 )
 
 // DeleteIpvlanInterface deletes a Pod's IPVLAN network interface based on the related DanmEp
@@ -231,14 +232,16 @@ func setDanmEpSysctls(ep *danmtypes.DanmEp) error {
 }
 
 func isIPv6Needed(ep *danmtypes.DanmEp) bool {
-  if ep.Spec.Iface.AddressIPv6 != "" {
+  _, err := os.Stat(V6SysPath + ep.Spec.Iface.Name)
+  if err == nil && ep.Spec.Iface.AddressIPv6 != "" {
     return true
   }
   return false
 }
 
 func isIPv6NotNeeded(ep *danmtypes.DanmEp) bool {
-  if ep.Spec.Iface.AddressIPv6 == "" {
+  _, err := os.Stat(V6SysPath + ep.Spec.Iface.Name)
+  if err == nil && ep.Spec.Iface.AddressIPv6 == "" {
     return true
   }
   return false

--- a/pkg/danmep/ep.go
+++ b/pkg/danmep/ep.go
@@ -144,13 +144,9 @@ func addIpToLink(ip string, iface netlink.Link) error {
   return nil
 }
 
-func addIpRoutes(ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
+func addIpRoutes(link netlink.Link, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
   defaultRoutingTable := 0
-  link, err := netlink.LinkByName(ep.Spec.Iface.Name)
-  if err != nil {
-    return errors.New("cannot find Pod interface: " + ep.Spec.Iface.Name + " for adding IP route because:" + err.Error())
-  }
-  err = addRouteForLink(dnet.Spec.Options.Routes, ep.Spec.Iface.Address, defaultRoutingTable, link)
+  err := addRouteForLink(dnet.Spec.Options.Routes, ep.Spec.Iface.Address, defaultRoutingTable, link)
   if err != nil {
     return err
   }
@@ -341,13 +337,9 @@ func createDummyInterface(ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
   return configureLink(iface, ep)
 }
 
-func disableDadOnIface(ep *danmtypes.DanmEp, isDummyIface bool) error {
-  if isDummyIface || ep.Spec.NetworkType == "ipvlan" || ep.Spec.Iface.AddressIPv6 == "" || ep.Spec.Iface.AddressIPv6 == ipam.NoneAllocType {
+func disableDadOnIface(link netlink.Link, ep *danmtypes.DanmEp) error {
+  if  ep.Spec.NetworkType == "ipvlan" || ep.Spec.Iface.AddressIPv6 == "" || ep.Spec.Iface.AddressIPv6 == ipam.NoneAllocType {
     return nil
-  }
-  link, err := netlink.LinkByName(ep.Spec.Iface.Name)
-  if err != nil {
-    return errors.New("cannot find interface to disable DAD on its V6 address because:" + err.Error())
   }
   addr, pref, _ := net.ParseCIDR(ep.Spec.Iface.AddressIPv6)
   dadlessAddress := &netlink.Addr{IPNet: &net.IPNet{IP: addr, Mask: pref.Mask}, Flags: syscall.IFA_F_NODAD,}


### PR DESCRIPTION
In this PR the post-processing done by DANM is restructured to accomodate CNIs which do not create kernel networking interfaces.
Userpsace CNIs, or various network config CNIs all belong to this category. When such a CNI is invoked through DANM, various post-processing errors related to automatically setting certain interface specific configs (v/, DAD, IP routes etc.) in the kernel would fail simply because the interface does not exist.

These issues are universally solved by checking for the presence of a kernel interface first, and only initiating post-processing if one is found.