### PR TITLE
Enable Cleaner to call static CNI specific API to release IPs

### DIFF
--- a/pkg/ipam/handler.go
+++ b/pkg/ipam/handler.go
@@ -1,0 +1,48 @@
+package ipam
+
+import (
+    "fmt"
+
+    danmtypes "github.com/nokia/danm/crd/apis/danm/v1"
+    danmclientset "github.com/nokia/danm/crd/client/clientset/versioned"
+)
+
+type ConditionFunc func(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) bool
+type ReleaseFunc func(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error
+
+type ipamHandler struct {
+    ConditionFunc ConditionFunc
+    ReleaseFunc   ReleaseFunc
+}
+
+func NewIpamHandler(conditionFunc ConditionFunc, releaseFunc ReleaseFunc) *ipamHandler {
+    return &ipamHandler{ConditionFunc: conditionFunc, ReleaseFunc: releaseFunc}
+}
+
+var CniHandlers = map[string]*ipamHandler {
+    "danm": NewIpamHandler(DanmIpamHandlerConditionFunc, DanmIpamHandlerReleaseFunc),
+}
+
+// DanmIpamHandlerConditionFunc tells if IP address was allocated by DANM IPAM
+// IP was allocated by DANM only if it falls into any of the defined subnets
+func DanmIpamHandlerConditionFunc(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) bool {
+    return WasIpAllocatedByDanm(ep.Spec.Iface.Address, dnet.Spec.Options.Cidr) || WasIpAllocatedByDanm(ep.Spec.Iface.AddressIPv6, dnet.Spec.Options.Pool6.Cidr)
+}
+
+//DanmIpamHandlerReleaseFunc
+func DanmIpamHandlerReleaseFunc(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
+    err := GarbageCollectIps(danmClient, dnet, ep.Spec.Iface.Address, ep.Spec.Iface.AddressIPv6)
+    if err != nil {
+        return fmt.Errorf("DanmEp: %s cannot be safely deleted because freeing its reserved IP addresses failed with error: %s", ep.ObjectMeta.Name, err)
+    }
+    return nil
+}
+
+func FindAndCallFirstIpamReleaseHandlerIfAny(danmClient danmclientset.Interface, ep *danmtypes.DanmEp, dnet *danmtypes.DanmNet) error {
+    for _, handler := range CniHandlers {
+        if handler.ConditionFunc(danmClient, ep, dnet) {
+            return handler.ReleaseFunc(danmClient, ep, dnet)
+        }
+    }
+    return nil
+}


### PR DESCRIPTION
Refactor danm DeleteDanmEp function pluginable enables injecting custom IP cleanup implementations of static CNIs on DanmEp delete

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, read our contributor guidelines https://github.com/nokia/danm/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
feature

**What does this PR give to us**:

**Which issue(s) this PR fixes** *(in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes nokia/danm-utils#24

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
