### PR TITLE
Adjust webhook timeout & Fix CNI timeout error message

### DIFF
--- a/integration/manifests/webhook/webhook.yaml
+++ b/integration/manifests/webhook/webhook.yaml
@@ -50,6 +50,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["danmnets","clusternetworks","tenantnetworks"]
     failurePolicy: Fail
+    timeoutSeconds: 25
   - name: danm-configvalidation.nokia.k8s.io
     clientConfig:
       service:
@@ -64,6 +65,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["tenantconfigs"]
     failurePolicy: Fail
+    timeoutSeconds: 25
   - name: danm-netdeletion.nokia.k8s.io
     clientConfig:
       service:
@@ -78,6 +80,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["danmnets","clusternetworks","tenantnetworks"]
     failurePolicy: Fail
+    timeoutSeconds: 25
 ---
 apiVersion: v1
 kind: Service

--- a/integration/manifests/webhook/webhook.yaml.tmpl
+++ b/integration/manifests/webhook/webhook.yaml.tmpl
@@ -49,6 +49,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["danmnets","clusternetworks","tenantnetworks"]
     failurePolicy: Fail
+    timeoutSeconds: 25
   - name: danm-configvalidation.nokia.k8s.io
     clientConfig:
       service:
@@ -62,6 +63,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["tenantconfigs"]
     failurePolicy: Fail
+    timeoutSeconds: 25
   - name: danm-netdeletion.nokia.k8s.io
     clientConfig:
       service:
@@ -75,6 +77,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["danmnets","clusternetworks","tenantnetworks"]
     failurePolicy: Fail
+    timeoutSeconds: 25
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/syncher/syncher.go
+++ b/pkg/syncher/syncher.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-  MaximumAllowedTime = 3000
+  MaximumAllowedTime = 3000  // Timeout = MaximumAllowedTime * RetryInterval[ms] = 30s
+  RetryInterval = 10         // [ms]
 )
 
 type cniOpResult struct {
@@ -47,7 +48,7 @@ func (synch *Syncher) GetAggregatedResult() error {
   //Time-out Pod creation if plugins did not provide results within the configured timeframe
   for i := 0; i < MaximumAllowedTime; i++ {
     if synch.ExpectedNumOfResults > len(synch.CniResults) {
-      time.Sleep(10 * time.Millisecond)
+      time.Sleep(RetryInterval * time.Millisecond)
       continue
     }
     if synch.wasAnyOperationErroneous() {
@@ -55,7 +56,7 @@ func (synch *Syncher) GetAggregatedResult() error {
     }
     return nil
   }
-  return errors.New("CNI operation timed-out after " + strconv.Itoa(MaximumAllowedTime) + " seconds")
+  return errors.New("CNI operation timed-out after " + strconv.Itoa(MaximumAllowedTime * RetryInterval / 1000) + " seconds")
 }
 
 func (synch *Syncher) wasAnyOperationErroneous() bool {

--- a/test.lonyal
+++ b/test.lonyal
@@ -1,1 +1,0 @@
-:sadsadsa

--- a/test/uts/syncher_test/syncher_test.go
+++ b/test/uts/syncher_test/syncher_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-  timeout = syncher.MaximumAllowedTime/100
+  timeout = syncher.MaximumAllowedTime * syncher.RetryInterval / 1000
 )
 
 type result struct {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR give to us**:
During CNI ADD/DEL operations DANM waits 30 seconds to finish all
the delegated CNI tasks and DanmEp processing. In case the webhook
is too slow to respond, DANM timeouts without knowing the reason.
The webhook REST call timeout is lowered to 25 seconds (by default
it is 30 sec), so its timeout event can arrive back to DANM, which
can log that error message.

**Which issue(s) this PR fixes**:
Related to #144, which is still a valid issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No.